### PR TITLE
fix: clear closed Prompt Writer modal semantics

### DIFF
--- a/tests/frontend_regressions.mjs
+++ b/tests/frontend_regressions.mjs
@@ -1259,6 +1259,13 @@ test("text-only Direct UI disables visual and Music modes and explains the fallb
   assert.match(skinSource, /\.h3ps-workspaces button:disabled/);
 });
 
+test("closed Prompt Writer does not advertise an active modal", () => {
+  assert.match(mainSource, /<section class="h3ps-modal" role="dialog" aria-label="H3 Prompt Writer" hidden>/);
+  assert.doesNotMatch(mainSource, /<section class="h3ps-modal" role="dialog" aria-modal="true"/);
+  assert.match(mainSource, /function openStudio\(\)[\s\S]{0,300}modal\.hidden = false;[\s\S]{0,120}modal\.setAttribute\("aria-modal", "true"\)/);
+  assert.match(mainSource, /function closeStudio\(\)[\s\S]{0,360}modal\.removeAttribute\("aria-modal"\);[\s\S]{0,100}modal\.hidden = true;/);
+});
+
 test("fullscreen reuses the studio root and persists its UI state", () => {
   assert.match(mainSource, /data-fullscreen-toggle/);
   assert.match(mainSource, /root\.classList\.toggle\("is-fullscreen", studio\.fullscreen\)/);

--- a/web/main.js
+++ b/web/main.js
@@ -2748,7 +2748,7 @@ function createStudio() {
   root.setAttribute("aria-hidden", "true");
   root.innerHTML = `
     <div class="h3ps-backdrop" data-close-studio></div>
-    <section class="h3ps-modal" role="dialog" aria-modal="true" aria-label="H3 Prompt Writer">
+    <section class="h3ps-modal" role="dialog" aria-label="H3 Prompt Writer" hidden>
       <header class="h3ps-header">
         <div class="h3ps-brand">
           <img class="h3ps-brandmark" src="${studioBrandIcon}" alt="H3 Prompt Writer">
@@ -3388,8 +3388,11 @@ function createStudio() {
 
 function openStudio() {
   const current = createStudio();
+  const modal = current.root.querySelector(".h3ps-modal");
   setMusicSystemPromptExpanded(false);
   syncMusicSystemPromptSummary();
+  modal.hidden = false;
+  modal.setAttribute("aria-modal", "true");
   current.root.classList.add("is-open");
   current.root.setAttribute("aria-hidden", "false");
   document.body.classList.add("h3ps-modal-open");
@@ -3398,10 +3401,13 @@ function openStudio() {
 
 function closeStudio() {
   if (!studio) return;
+  const modal = studio.root.querySelector(".h3ps-modal");
   setSettingsOpen(false);
   setOtherModelsPopover(false);
   closeVideoPreview();
   closeImagePreview();
+  modal.removeAttribute("aria-modal");
+  modal.hidden = true;
   studio.root.classList.remove("is-open");
   studio.root.setAttribute("aria-hidden", "true");
   document.body.classList.remove("h3ps-modal-open");


### PR DESCRIPTION
## Summary

Fix the Prompt Writer modal lifecycle so ComfyUI only sees it as an active modal while the Prompt Writer is actually open.

The dialog previously existed with `aria-modal="true"` even while the Prompt Writer root was closed. Current ComfyUI frontend modal/shortcut handling can therefore identify the hidden Prompt Writer as an active modal and route keyboard handling through it. One observable regression is the global **Ctrl+S / Cmd+S save shortcut no longer reaching ComfyUI while Prompt Writer is closed**.

This patch makes the dialog's DOM and accessibility state follow its real lifecycle.

## Changes

* create the Prompt Writer dialog with `hidden`
* do not advertise `aria-modal="true"` while the Prompt Writer is closed
* when opening:

  * clear `hidden`
  * set `aria-modal="true"`
  * expose the Prompt Writer root
* when closing:

  * remove `aria-modal`
  * restore `hidden`
  * hide the Prompt Writer root
* add a frontend regression test covering the complete closed → open → closed lifecycle

The change is deliberately limited to modal state management. It does not alter Prompt Writer keyboard shortcuts, ComfyUI's global keyboard handling, or unrelated frontend behavior.

## Why

A closed dialog must not continue to advertise itself as an active modal.

Keeping the nested dialog modal-active while its surrounding Prompt Writer UI is closed creates stale modal state for code that discovers active dialogs from DOM semantics. This became visible after frontend changes in ComfyUI's modal and shortcut handling.

The invariant after this patch is:

> A Prompt Writer dialog has active modal semantics if and only if Prompt Writer is open.

## Files changed

* `web/main.js`
* `tests/frontend_regressions.mjs`

## Validation

Prepared as one commit on current upstream `main`:

`424248b3153d5792de2b74651bdeb97789892464`

Exact contribution head:

`49acf0e3118b7f850d530a282189dd5b5b66a65b`

Validation run `33554980641` passed:

* Python: **294 tests**
* frontend: **61/61**

No unrelated changes are included.
