### PR TITLE
feat: add native H3 Continuum prompt workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,18 +1,173 @@
-name: Test
+name: tests
 
 on:
   push:
+    branches: [main]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
 
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  test:
+  unit:
+    name: Python ${{ matrix.python-version }} · unit/static
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.10"
+          - "3.12"
+          - "3.13"
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository
+      - name: Check out Prompt Writer
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements.txt
+            requirements-gguf.txt
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ruff aiohttp "av>=17.0.0" pillow
+
+      - name: Run static Python checks
+        run: |
+          python -m ruff check backend tests --select E9,F63,F7,F82
+          python -m compileall -q backend tests
+
+      - name: Run Python unit suite
+        env:
+          PYTHONPATH: tests/ci_stubs
+        run: python -m unittest discover -s tests -p "test_*.py"
+
+  frontend:
+    name: Node 22 · frontend regressions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Prompt Writer
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Check JavaScript syntax
+        run: |
+          find web tests -type f \( -name '*.js' -o -name '*.mjs' \) -print0 | xargs -0 -n1 node --check
+
+      - name: Run frontend regression suite
+        run: node --test tests/frontend_regressions.mjs tests/test_continuum_image_conveyor.mjs
+
+  standalone-windows:
+    name: Windows · standalone/build contracts
+    runs-on: windows-latest
+    steps:
+      - name: Check out Prompt Writer
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: standalone/requirements.txt
+
+      - name: Install standalone test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r standalone/requirements.txt ruff
+
+      - name: Run standalone static checks
+        run: |
+          python -m ruff check standalone/h3_standalone standalone/tests --select E9,F63,F7,F82
+          python -m compileall -q standalone/h3_standalone standalone/tests
+
+      - name: Build extension package
+        shell: powershell
+        run: powershell -ExecutionPolicy Bypass -File scripts\build_extension.ps1
+
+      - name: Build standalone package
+        shell: powershell
+        run: powershell -ExecutionPolicy Bypass -File scripts\build_standalone.ps1
+
+      - name: Run standalone test suite
+        env:
+          PYTHONPATH: ${{ github.workspace }};${{ github.workspace }}\standalone
+        run: python -m unittest discover -s standalone/tests -p "test_*.py"
+
+  continuum-contract:
+    name: H3 Continuum V3.4–V3.7 · reviewed contract
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Prompt Writer
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Check out reviewed H3 Continuum source
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          repository: ukr8b3g-cmyk/ComfyUI-H3-Continuum
+          ref: 0a7c6703b7715689c7aab4177e44e5fcd318fe5b
+          path: .continuum-source
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements.txt
+
+      - name: Install contract-test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest aiohttp "av>=17.0.0" pillow
+
+      - name: Run focused Continuum contract suites
+        env:
+          PYTHONPATH: tests/ci_stubs
+          H3_CONTINUUM_SOURCE: ${{ github.workspace }}/.continuum-source
+        run: python -m unittest discover -s tests -p "test_continuum*.py"
+
+  image-conveyor-contract:
+    name: Image Conveyor 1.7.2 · reviewed contract
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Prompt Writer
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Check out reviewed Image Conveyor source
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          repository: xmarre/ComfyUI-Image-Conveyor
+          ref: e316cb028f21105a8ea303ace30d9d92acff6198
+          path: .image-conveyor-source
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -24,13 +179,58 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Install test dependencies
-        run: python -m pip install aiohttp av pillow
-
-      - name: Run Python tests
+      - name: Run Prompt Writer cross-repository contract
         env:
-          PYTHONPATH: tests/ci_stubs
-        run: python -m unittest discover -s tests -p "test_*.py"
+          IMAGE_CONVEYOR_SOURCE: ${{ github.workspace }}/.image-conveyor-source
+        run: python -m unittest discover -s tests -p "test_image_conveyor_cross_repo.py"
 
-      - name: Run frontend tests
-        run: node --test tests/frontend_regressions.mjs
+      - name: Run reviewed Image Conveyor topology suites
+        working-directory: .image-conveyor-source
+        run: node --test tests/test_reference_toggles.mjs tests/test_toggle_state_sync.mjs tests/test_queue_groups.mjs
+
+  scale-image-total-pixels-x-contract:
+    name: Scale Image to Total Pixels Adv · reviewed contract
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Prompt Writer
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Check out reviewed scaler source
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          repository: BigStationW/ComfyUi-Scale-Image-to-Total-Pixels-Advanced
+          ref: 79e831097bb7a76ade3a28359300e62332086c42
+          path: .scale-image-total-pixels-x-source
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run scaler cross-repository contract
+        env:
+          SCALE_IMAGE_TOTAL_PIXELS_X_SOURCE: ${{ github.workspace }}/.scale-image-total-pixels-x-source
+        run: python -m unittest discover -s tests -p "test_scale_image_total_pixels_x_cross_repo.py"
+
+  hygiene:
+    name: Repository hygiene
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Prompt Writer
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Check patch whitespace
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [ -n "$BASE_REF" ]; then
+            git diff --check "origin/$BASE_REF...HEAD"
+          else
+            git diff-tree --check --no-commit-id --root -r HEAD
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 ## Unreleased
 
+### Features
+
+- Added H3 Continuum as a separate video output target with native 1–16 chunk and 4–30 second controls (5–15 seconds recommended).
+- Added validated continuity planning followed by sequential chunk-local H3 prompt generation and canonical Continuum Timeline serialization with one shared sequence-wide H3 preamble.
+- Added deterministic integer and fractional Timeline boundaries and strict Writer-side validation instead of relying on Continuum's Fixed fallback.
+- Added chunk-local refinement that preserves the shared preamble and every unchanged chunk body byte-for-byte, with hashes computed from the exact resolved prompts Continuum receives.
+- Added an explicit graph handoff for H3 Continuum Sampler V3.4–V3.7 with unambiguous sampler selection, **Prompt Format = Timeline** compatibility, settings mismatch review, connected Text (Multiline) updates, and clipboard fallback.
+- Added downstream H3 Continuum conditioning discovery with exact public identity rules: Reference Images own compact `<Picture N>` numbering in hybrid runs; keyframe-only First/Last inputs own temporal Picture identities; Video Reference is persistent `<Video 1>`; V3.5+ Reference Audio is persistent `<Audio 1>`; Driving Audio remains untagged.
+
+### Reliability
+
+- Aligned Continuum compatibility with current upstream V3.4–V3.7 samplers, including the V3.5+ Reference Audio `<Audio 1>` contract and native 4–30-second chunk range while retaining 5–15 seconds as the recommended range.
+
+- Hardened H3 Continuum sequence-plan recovery after schema drift: the one bounded repair pass now retains the complete original planner contract instead of replacing it with a weaker repair-only system prompt, explicitly rechecks non-empty shared preamble and numeric stable-subject IDs, and canonicalizes reserved model aliases such as `<Subject A>` → `<Subject 1>` consistently across the plan before validation.
+- Added bounded deterministic planner-contract recovery before/after the single LLM repair: one identifiable plan JSON object may be extracted from harmless wrapper prose; optional internal text fields may default to their allowed empty form; application-owned indexes/assignments are removed; and an empty shared preamble is replaced with one synthesized only from existing global subject/continuity/constraint semantics plus authoritative persistent reference identities, with a content-neutral continuity fallback. Missing chunk semantics, wrong chunk count, subject/reference drift, and scope violations remain strict errors.
+- Added exact pre-execution materialization for stable workflow references passed through the reviewed `ImageScaleToTotalPixelsX` / **Scale Image to Total Pixels Adv** node (contract pinned to `79e831097bb7a76ade3a28359300e62332086c42`). Static megapixel/multiple and stretch/crop/pad chains using Lanczos now import the transformed H3 reference instead of being rejected as a generic processed image chain.
+- Transform settings are included in downstream source identity, so changing scaler parameters produces **Update needed**. Any connected runtime override for width, height, megapixels, multiple-of, resize mode, or interpolation fails closed rather than using a stale widget value; non-Lanczos methods, animated sources, unsupported upstreams, and arbitrary processing chains remain unavailable.
+- After materialization, the Active workflow images row previews the actual post-transform Prompt Writer asset seen by the prompt model rather than the upstream source thumbnail.
+- Added a dedicated backend materialization endpoint, exact Lanczos/crop geometry regression tests, route coverage, frontend chain tests, and a pinned cross-repository scaler contract CI lane.
+- Added the missing **Active workflow images** UI for Reference + H3 Continuum, including **Add active workflow refs**, per-slot Add/Update state, ComfyUI image materialization for stable Image Conveyor Reference Shelf and direct Load Image sources, and exact downstream `model_asset_id` binding so the prompt model can inspect the same references that will condition H3.
+- Dynamic queue-group/queue-driven sources and processed image chains remain visible as active workflow conditioning but are deliberately not imported as fake stable media when their exact execution pixels are not available yet.
+- Apply-to-Continuum now compares downstream workflow source identity separately from Prompt Writer media visibility/binding, so a correctly bound model-visible copy does not look like graph source drift.
+- Re-materializing the same stable workflow reference after a Prompt Writer session reload may use a new temporary media asset ID without falsely triggering source drift only when the saved stable workflow fingerprint still matches; unfingerprinted bindings stay strict. Model visibility remains part of the contract. Manually replacing an imported copy drops its workflow binding so unrelated pixels cannot continue masquerading as that downstream Picture.
+- Added first-class Image Conveyor compatibility for Continuum conditioning discovery, honoring persistent Reference Shelf population/output switches, Main/Last Frame switches, Queue execution-group size, the legacy node alias, and single-image transform/bypass chains instead of trusting visible wires alone.
+- Added opaque saved source fingerprints for persistent Image Conveyor Reference Shelf images so shelf replacements trigger Continuum source-drift protection without storing filenames; queue-group members remain intentionally dynamic. Legacy saved inventories without fingerprints are accepted once against otherwise identical topology and upgraded to the active fingerprint on successful refinement.
+- Added a pinned Image Conveyor 1.7.2 cross-repository CI contract alongside Prompt Writer's frontend coverage.
+- Relaxed Continuum's internal `continuity_anchors` and `persistent_constraints` to allow intentionally empty text while still requiring the fields and their types; they no longer abort otherwise valid plans with no extra sequence-wide metadata.
+- Changed the single bounded Continuum planner repair to audit and repair the complete schema contract rather than fixing only the first validation failure and exposing the next one.
+- Added deterministic structural sequence persistence without storing provider secrets.
+- Separated model-visible Prompt Writer media from downstream H3 conditioning identities. Workflow-only references can be declared without sending their pixels to the prompt model, and uploaded analysis media cannot silently impersonate a downstream `<Picture N>`.
+- Added explicit model-asset binding validation for future verified media reuse, rejecting missing, wrong-type, and duplicate bindings.
+- Added cross-repository CI that checks Writer Timeline output against the current H3 Continuum `v2/prompts.py` parser and verifies exact resolved prompts and SHA-256 hashes.
+- Added sequence progress, cancellation, exact chunk-failure reporting, bounded one-shot plan repair, chunk-scoped reference validation with a narrow Continuum-only correction pass, final-stage unload behavior, and cumulative provider accounting.
+- Added temporal-mode validation against the selected H3 Continuum First/Last Frame wiring and blocked generation, refinement, or handoff when the selected mode does not match the active keyframe topology.
+- Added saved downstream-conditioning snapshots so later refinement and graph handoff reject observable source rewiring that would silently reuse the same public reference tags for different workflow inputs.
+- Added native Continuum chunk-body validation for repeated shared preambles, standalone H3 field/shot wrappers, nested Timeline headers, keyframe-alignment boilerplate, and undeclared subject identities.
+- Made **Sync settings & apply** transactional: Writer now resolves the editable Sequence Prompt target before mutation and restores sampler/text widget values if a graph callback fails.
+- Fixed Continuum draft persistence after the schema-v2 contract rework: saved sequences now retain their shared preamble and downstream-conditioning snapshot, while legacy schema-v1 drafts migrate to v2 on save/load.
+- Restricted legacy `[Chunk N]` migration to genuinely legacy saved sequences so schema-v2 Timeline drafts cannot silently discard their shared preamble.
+
+### Fixes
+
+- Extended LM Studio metadata and capability discovery to Custom endpoints on private LAN addresses, matching the existing Custom-provider HTTP security policy.
+
 ## 0.4.4 - 2026-09-02
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Use <Picture 1> for character appearance, <Picture 2> for clothes, and only the 
 
 Writer sends your brief, selected mode, prepared references, and the official MiniMax prompt-writing guide to the chosen prompt model. The result is an editable H3 prompt. You can change it directly, use **Refine** for a revision, or select **Copy prompt** and paste it into your H3 workflow.
 
+For longer shots, choose **H3 Continuum** as the output target. Writer creates one sequence-wide H3 preamble plus canonical Timeline sections such as `[0-5s]`, `[5-10s]`, and later spans for the [H3 Continuum](https://github.com/ukr8b3g-cmyk/ComfyUI-H3-Continuum) V3.4–V3.7 sampler family. Continuum prepends the shared preamble to every resolved chunk, so persistent identity, reference roles, wardrobe, environment, style, camera, lighting, audio rules, and exclusions can remain truly sequence-wide. This is a separate target, not another H3 mode; T2VA, I2VA, FL2VA, L2VA, and Reference keep their existing media semantics.
+
 ## Key features
 
 - T2VA, I2VA, FL2VA, L2VA, and Reference modes.
@@ -53,6 +55,9 @@ Writer sends your brief, selected mode, prepared references, and the official Mi
 - Ordered video contact sheets with visible frame-sampling controls, so you can inspect what the prompt model sees.
 - Official MiniMax base and Reference guides included for all five modes.
 - Editable prompts, **Refine**, **Copy prompt**, and a separate saved draft for every mode.
+- Native H3 Continuum sequences from 1 to 16 chunks at 4 to 30 seconds per chunk (5–15 seconds recommended), with a shared sequence preamble, canonical Timeline output, chunk-local refinement, and an explicit **Apply to Continuum** handoff.
+- Continuum derives public reference identities from the selected supported sampler topology: active **Reference Image** inputs own compact `<Picture 1..N>` numbering in hybrid runs; without Reference Images, **First Frame** and **Last Frame** own compact temporal `<Picture N>` identities; **Video Reference** is `<Video 1>`; **Reference Audio** on V3.5+ is persistent `<Audio 1>`; **Driving Audio** is persistent conditioning with no `<Audio N>` prompt tag. V3.7's optional Still Image Guide remains workflow-owned and untagged.
+- Native [Image Conveyor](https://github.com/xmarre/ComfyUI-Image-Conveyor) compatibility resolves its effective runtime outputs instead of trusting saved wires: disabled or empty persistent Reference Shelf slots stay out of the Continuum Picture inventory, Main/Last Frame switches are honored, and Queue execution groups follow **Images per execution**. In **Reference + H3 Continuum**, the Media section also shows the currently active workflow image slots and provides **Add active workflow refs** so stable Conveyor Reference Shelf / Load Image pixels can be inspected by the prompt model and bound to the same downstream identities. A stable reference passed through the reviewed `ImageScaleToTotalPixelsX` **Scale Image to Total Pixels Adv** node is materialized before import when it uses static megapixel/multiple/crop-pad-stretch settings and **Lanczos**, so Writer sees the resized/cropped image that actually reaches H3 instead of the pre-transform source.
 - Automatic context planning and clear controls for releasing local prompt models and ComfyUI VRAM.
 
 See [Writing a useful Creative Brief](docs/USAGE.md#writing-a-useful-creative-brief) for practical examples.
@@ -81,6 +86,8 @@ Not sure? Start with [Ollama](docs/OLLAMA.md). The [provider guide](docs/PROVIDE
 4. Choose a mode, add its media, and write a Creative Brief.
 5. Select **Generate prompt**, review the editable result, then copy it into your H3 workflow.
 
+To write a longer sequence, select **H3 Continuum**, choose the chunk count and seconds per chunk, then select **Generate sequence**. See [H3 Continuum sequences](docs/USAGE.md#h3-continuum-sequences).
+
 For Git, ZIP, Windows Portable, update, and provider-specific steps, see [Installation](docs/INSTALLATION.md).
 
 ## Privacy and limitations
@@ -89,11 +96,12 @@ For Git, ZIP, Windows Portable, update, and provider-specific steps, see [Instal
 - With a remote API provider, the required brief, instructions, prepared images, and video contact sheets are sent to the selected provider. Original video and audio bytes are not uploaded by Writer. Read [What leaves this computer](docs/API_PROVIDERS.md#what-leaves-this-computer) before using private media.
 - Video understanding uses the ordered contact sheet shown in the preview, not every frame of the encoded video.
 - Prompt models do not listen to uploaded audio. Describe the soundtrack, voice, rhythm, or other audio role in the Creative Brief.
+- Continuum can declare downstream workflow references without copying their pixels into the prompt-model request. A workflow-only Reference Image can therefore keep its `<Picture N>` identity while remaining unseen by the prompt model; describe its intended role in the Creative Brief instead of expecting visual inference.
 - The interface and documentation are in English. Briefs can use other languages, and Writer preserves supplied dialogue and visible text.
 - Gemma 4 remains the simplest tested local choice. Direct GGUF also supports Qwen 3.8, compatible Qwen 3.8 fine-tunes, and Qwen3-VL. Untested compatible models may behave differently from the verified pairs.
 - Ollama, External llama.cpp, and compatible API endpoints let you try other multimodal models that accept images. Compatibility does not guarantee a good H3 prompt.
-- External llama.cpp also accepts text-only models for Music 3, T2VA, and Refine. Image and video requests still need a vision model.
-- Direct GGUF supports Gemma 4, Qwen 3.8, compatible Qwen 3.8 fine-tunes, and Qwen3-VL. The tested Qwen 3.8 and Qwen3-VL model and projector pairs are marked as verified. Other compatible combinations are marked as unverified. A missing projector leaves text-only T2VA available.
+- External llama.cpp also accepts text-only models for Music 3, T2VA, ordinary text-only Refine, and H3 Continuum modes whose visual conditioning stays workflow-only. Prompt Writer image/video analysis still needs a vision model.
+- Direct GGUF supports Gemma 4, Qwen 3.8, compatible Qwen 3.8 fine-tunes, and Qwen3-VL. The tested Qwen 3.8 and Qwen3-VL model and projector pairs are marked as verified. Other compatible combinations are marked as unverified. A missing projector leaves text-only T2VA plus workflow-only H3 Continuum available.
 - Gemini and a Custom OpenAI-compatible endpoint were tested live. OpenAI and OpenRouter have automated contract coverage but were not tested live with commercial credentials. Comfy Cloud has not been validated for v0.3.
 
 ## Documentation

--- a/backend/assembly.py
+++ b/backend/assembly.py
@@ -5,7 +5,12 @@ from typing import Any
 
 from .guides import MODE_GUIDES, guide_for_mode, load_guide, reference_base_excerpt
 from .media import STORE, MediaError, parse_session_id
-from .references import canonical_reference_tags
+from .references import (
+    bind_downstream_reference_inventory,
+    canonical_reference_tags,
+    missing_reference_declarations,
+    model_media_labels,
+)
 from .system_prompts import SystemPromptError, resolve_system_prompt
 from .text_normalization import normalize_unicode_text
 
@@ -30,7 +35,7 @@ def _required_text(body: dict[str, Any], key: str, label: str) -> str:
     return normalize_unicode_text(value).strip()
 
 
-def _media_line(asset: dict[str, Any]) -> str:
+def _media_line(asset: dict[str, Any], label: str | None = None) -> str:
     detail = asset["type"]
     if asset.get("duration") is not None:
         detail += f", {asset['duration']:g}s"
@@ -40,7 +45,7 @@ def _media_line(asset: dict[str, Any]) -> str:
             detail += f", sampled frames at {times}"
     elif asset["type"] == "audio":
         detail += ", not analyzed by the local model; role must come only from the user's brief"
-    return f"{asset.get('reference', asset['filename'])}: {asset['filename']} ({detail})"
+    return f"{label or asset.get('reference', asset['filename'])}: {asset['filename']} ({detail})"
 
 
 def _effective_system_prompt(body: dict[str, Any], mode: str) -> tuple[str, bool]:
@@ -50,12 +55,37 @@ def _effective_system_prompt(body: dict[str, Any], mode: str) -> tuple[str, bool
         raise AssemblyError(error.code, error.message) from error
 
 
-def _validate_reference_tags(text: str, manifest: dict[str, Any], mode: str, field_label: str) -> None:
-    if mode != "Reference":
+def _validate_reference_tags(
+    text: str,
+    manifest: dict[str, Any],
+    mode: str,
+    field_label: str,
+    *,
+    downstream_reference_inventory: dict[str, Any] | None = None,
+    continuum: bool = False,
+) -> None:
+    if mode != "Reference" and not continuum:
         return
-    available = {asset["reference"] for asset in manifest["assets"]}
-    canonical_tags = canonical_reference_tags(text)
-    missing = sorted(canonical_tags - available)
+    request_input: dict[str, Any] = {"mode": mode, "media_manifest": manifest}
+    if downstream_reference_inventory is not None:
+        request_input["downstream_reference_inventory"] = downstream_reference_inventory
+    if continuum:
+        missing = missing_reference_declarations(request_input, [text], continuum=True)
+        if missing:
+            tag = missing[0]
+            raise AssemblyError(
+                "REFERENCE_NOT_DECLARED",
+                f"{tag} is referenced in the {field_label} but is not declared by the selected H3 Continuum V3.4 sampler inventory.",
+                {"reference": tag, "missing": missing},
+            )
+        return
+
+    available = {
+        str(asset["reference"])
+        for asset in manifest.get("assets", [])
+        if asset.get("reference")
+    }
+    missing = sorted(canonical_reference_tags(text) - available)
     if missing:
         tag = missing[0]
         raise AssemblyError(
@@ -202,14 +232,31 @@ def assemble_request(body: dict[str, Any]) -> dict[str, Any]:
     manifest = STORE.manifest(session_id, mode)
     if not manifest["valid"]:
         raise AssemblyError("INVALID_MEDIA_MANIFEST", "The media manifest is not valid.", manifest["violations"])
+    downstream_inventory = None
+    if "downstream_reference_inventory" in body:
+        try:
+            downstream_inventory = bind_downstream_reference_inventory(
+                body.get("downstream_reference_inventory"),
+                manifest,
+            )
+        except ValueError as error:
+            raise AssemblyError("INVALID_DOWNSTREAM_REFERENCE_INVENTORY", str(error)) from error
 
-    _validate_reference_tags(brief, manifest, mode, "Creative Brief")
+    _validate_reference_tags(
+        brief,
+        manifest,
+        mode,
+        "Creative Brief",
+        downstream_reference_inventory=downstream_inventory,
+        continuum=body.get("generation_target") == "continuum",
+    )
     declared_references = manifest["assets"]
+    media_labels = model_media_labels(manifest, downstream_inventory, mode=mode)
     eligible = [asset for asset in declared_references if asset["type"] != "audio"]
     media_inputs = [
         {
             "asset_id": asset["id"],
-            "reference": asset.get("reference"),
+            "reference": media_labels.get(str(asset["id"]), asset.get("reference")),
             "type": asset["type"],
             "requires_capability": CAPABILITY_BY_TYPE[asset["type"]],
             "frames": [
@@ -230,13 +277,27 @@ def assemble_request(body: dict[str, Any]) -> dict[str, Any]:
         }
         for asset in eligible
     ]
-    references = "\n".join(_media_line(asset) for asset in declared_references) or "None"
+    references = "\n".join(
+        _media_line(asset, media_labels.get(str(asset.get("id"))))
+        for asset in declared_references
+    ) or "None"
+    downstream_lines = "None"
+    if downstream_inventory is not None:
+        downstream_lines = "\n".join(
+            f"- {item.get('tag') or item['role']}: {item['kind']} via {item['role']} "
+            f"(visible to prompt model: {'yes' if item['visible_to_model'] else 'no'})"
+            for item in downstream_inventory["items"]
+        ) or "None"
     user_content = (
         f"Mode: {mode}\n"
         f"Duration: {duration:g} seconds\n"
         f"Aspect ratio: {aspect_ratio}\n\n"
-        "Reference manifest (audio is not analyzed by the local model; derive its copy/reference role only from the user's words and do not invent its content):\n"
+        "Model-visible media manifest (audio is not analyzed by the local model; derive its copy/reference role only from the user's words and do not invent its content):\n"
         f"{references}\n\n"
+        "Declared downstream H3 conditioning inventory (these inputs exist in the generation workflow. "
+        "An item marked not visible to the prompt model has not been visually or audibly inspected here; preserve its "
+        "public tag when relevant and never invent its appearance or contents unless the Creative Brief states them):\n"
+        f"{downstream_lines}\n\n"
         f"Creative brief:\n{brief}\n\n"
         f"{_final_contract(mode, brief)}"
     )
@@ -250,6 +311,7 @@ def assemble_request(body: dict[str, Any]) -> dict[str, Any]:
             "aspect_ratio": aspect_ratio,
             "creative_brief": brief,
             "media_manifest": manifest,
+            **({"downstream_reference_inventory": downstream_inventory} if downstream_inventory is not None else {}),
         },
         "media_inputs": media_inputs,
         "supporting_guides": ([{
@@ -320,11 +382,42 @@ def assemble_refinement(
     manifest = STORE.manifest(session_id, mode)
     if not manifest["valid"]:
         raise AssemblyError("INVALID_MEDIA_MANIFEST", "The media manifest is not valid.", manifest["violations"])
+    downstream_inventory = None
+    if "downstream_reference_inventory" in body:
+        try:
+            downstream_inventory = bind_downstream_reference_inventory(
+                body.get("downstream_reference_inventory"),
+                manifest,
+            )
+        except ValueError as error:
+            raise AssemblyError("INVALID_DOWNSTREAM_REFERENCE_INVENTORY", str(error)) from error
     context_source = cached_generation if cached_generation and cached_generation.get("mode") == mode else body
     duration, aspect_ratio, creative_brief = _validated_generation_context(context_source)
-    _validate_reference_tags(creative_brief, manifest, mode, "Creative Brief")
-    _validate_reference_tags(instruction, manifest, mode, "Revision instruction")
-    references = "\n".join(_media_line(asset) for asset in manifest["assets"]) or "None"
+    continuum = body.get("generation_target") == "continuum"
+    _validate_reference_tags(
+        creative_brief, manifest, mode, "Creative Brief",
+        downstream_reference_inventory=downstream_inventory, continuum=continuum,
+    )
+    _validate_reference_tags(
+        current_prompt, manifest, mode, "Current prompt",
+        downstream_reference_inventory=downstream_inventory, continuum=continuum,
+    )
+    _validate_reference_tags(
+        instruction, manifest, mode, "Revision instruction",
+        downstream_reference_inventory=downstream_inventory, continuum=continuum,
+    )
+    media_labels = model_media_labels(manifest, downstream_inventory, mode=mode)
+    references = "\n".join(
+        _media_line(asset, media_labels.get(str(asset.get("id"))))
+        for asset in manifest["assets"]
+    ) or "None"
+    downstream_lines = "None"
+    if downstream_inventory is not None:
+        downstream_lines = "\n".join(
+            f"- {item.get('tag') or item['role']}: {item['kind']} via {item['role']} "
+            f"(visible to prompt model: {'yes' if item['visible_to_model'] else 'no'})"
+            for item in downstream_inventory["items"]
+        ) or "None"
     guide = guide_for_mode(mode)
     user_content = (
         "Rewrite the current H3 prompt according to the revision instruction. "
@@ -333,7 +426,10 @@ def assemble_refinement(
         f"Original duration: {duration:g} seconds\n"
         f"Original aspect ratio: {aspect_ratio}\n"
         f"Original Creative Brief:\n{creative_brief}\n\n"
-        f"Reference manifest (text only; media is intentionally not attached):\n{references}\n\n"
+        f"Model-visible media manifest (text only; media is intentionally not attached):\n{references}\n\n"
+        "Declared downstream H3 conditioning inventory (not re-uploaded during refinement; items marked not visible were "
+        "never inspected by the prompt model, so do not invent their appearance or contents):\n"
+        f"{downstream_lines}\n\n"
         f"Current prompt:\n{current_prompt}\n\n"
         f"Revision instruction:\n{instruction}\n\n"
         "Reference revision rule: preserve each existing <Audio N> that is absent from the Revision instruction. "
@@ -353,6 +449,7 @@ def assemble_refinement(
             "current_prompt": current_prompt,
             "instruction": instruction,
             "media_manifest": manifest,
+            **({"downstream_reference_inventory": downstream_inventory} if downstream_inventory is not None else {}),
         },
         "media_inputs": [],
         "supporting_guides": ([{

--- a/backend/catalog.py
+++ b/backend/catalog.py
@@ -189,7 +189,11 @@ def _model_candidate(
     else:
         projector, vision_status, pairing_message = None, "incompatible", "Vision is disabled because the model metadata could not be read."
     pairing_issue = f"{model_path}: {pairing_message}" if pairing_message else None
-    text_fallback = " T2VA remains available." if not missing_dependencies else ""
+    text_fallback = (
+        " T2VA and workflow-only H3 Continuum remain available."
+        if not missing_dependencies
+        else ""
+    )
     capability_message = None if vision_status == "compatible" else f"Vision unavailable: {pairing_message}{text_fallback}"
 
     configured = _configured_models().get(model_path.name, {}) if metadata and architecture_recognized else {}

--- a/backend/context.py
+++ b/backend/context.py
@@ -29,6 +29,7 @@ CHAT_TEMPLATE_OVERHEAD_TOKENS = 384
 MINIMUM_OUTPUT_TOKENS = 1_536
 MUSIC_OUTPUT_TOKENS = 1_536
 STANDARD_OUTPUT_TOKENS = 2_048
+CONTINUUM_PLAN_OUTPUT_TOKENS = 8_192
 THINKING_OUTPUT_TOKENS = 6_144
 LOCAL_THINKING_OUTPUT_TOKENS = 8_192
 
@@ -146,7 +147,10 @@ def estimate_visual_tokens(
 
 
 def non_thinking_output_tokens(assembled: dict[str, Any]) -> int:
-    mode = assembled.get("input", {}).get("mode")
+    request_input = assembled.get("input", {})
+    if request_input.get("continuum_stage") in {"plan", "plan_repair"}:
+        return CONTINUUM_PLAN_OUTPUT_TOKENS
+    mode = request_input.get("mode")
     return MUSIC_OUTPUT_TOKENS if mode == "Music3" else STANDARD_OUTPUT_TOKENS
 
 

--- a/backend/continuum.py
+++ b/backend/continuum.py
@@ -1,0 +1,1845 @@
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+import copy
+import hashlib
+import json
+import re
+from typing import Any
+
+from .assembly import assemble_refinement, assemble_request
+from .references import (
+    effective_reference_tags,
+    missing_reference_declarations,
+    normalize_downstream_reference_inventory,
+    reference_tags,
+)
+
+
+GENERATION_TARGET_SINGLE = "single"
+GENERATION_TARGET_CONTINUUM = "continuum"
+CONTINUUM_SCHEMA_VERSION = 2
+LEGACY_CONTINUUM_SCHEMA_VERSION = 1
+MIN_CHUNKS = 1
+MAX_CHUNKS = 16
+MIN_CHUNK_SECONDS = 4.0
+MAX_CHUNK_SECONDS = 30.0
+
+_LEGACY_CHUNK_HEADER = re.compile(r"^\s*\[\s*Chunk\s+(\d+)\s*\]\s*$", re.IGNORECASE)
+_TIMELINE_HEADER = re.compile(
+    r"^\s*\[\s*(\d+(?:\.\d+)?)\s*-\s*(\d+(?:\.\d+)?)\s*s?\s*\]\s*$",
+    re.IGNORECASE,
+)
+_FENCE = re.compile(r"^\s*```(?:json)?\s*(.*?)\s*```\s*$", re.IGNORECASE | re.DOTALL)
+_SUBJECT_TAG = re.compile(r"<\s*Subject\s+(\d+)\s*>", re.IGNORECASE)
+_SUBJECT_ALPHA_ALIAS_TAG = re.compile(r"<\s*Subject\s+([A-Z])\s*>", re.IGNORECASE)
+_CONTINUUM_STANDALONE_FIELD = re.compile(
+    r"^\s*(integrated_multimodal_description|subject_definitions|summary|retention_analysis|"
+    r"detailed_description|overall_soundscape|non_diegetic_music)\s*:",
+    re.IGNORECASE | re.MULTILINE,
+)
+_CONTINUUM_SHOT_HEADER = re.compile(
+    r"(?:^|:\s*)\[\s*Shot\s+\d+\s*\]",
+    re.IGNORECASE | re.MULTILINE,
+)
+_CONTINUUM_ALIGNMENT_BOILERPLATE = re.compile(
+    r"^\s*(?:How\s+the\s+reference\s+picture(?:s)?\s+align\s+with\s+the\s+target\s+video\s*:|"
+    r"For\s+the\s+target\s+video\s*,\s*at\s+0(?:\.0+)?\s+seconds\b)",
+    re.IGNORECASE | re.MULTILINE,
+)
+_CONTINUUM_MARKDOWN_FENCE = re.compile(r"^\s*\x60\x60\x60", re.MULTILINE)
+
+
+def subject_tags(text: str) -> set[str]:
+    return {
+        f"<Subject {int(number)}>"
+        for number in _SUBJECT_TAG.findall(str(text))
+        if int(number) > 0
+    }
+
+
+def _subject_alpha_alias_number(value: str) -> int:
+    return ord(value.upper()) - ord("A") + 1
+
+
+def _normalize_plan_subject_aliases(value: str) -> str:
+    return _SUBJECT_ALPHA_ALIAS_TAG.sub(
+        lambda match: f"<Subject {_subject_alpha_alias_number(match.group(1))}>",
+        str(value),
+    )
+
+
+def continuum_chunk_format_violations(
+    prompt: str,
+    *,
+    preamble: str = "",
+) -> list[str]:
+    value = str(prompt or "").strip()
+    violations: list[str] = []
+    shared = str(preamble or "").strip()
+    if shared and (value == shared or value.startswith(shared + "\n") or value.startswith(shared + "\r")):
+        violations.append("repeated shared sequence preamble")
+    if _contains_reserved_sequence_header(value):
+        violations.append("reserved Continuum Timeline or legacy chunk header")
+    standalone_fields = sorted({
+        match.group(1).lower()
+        for match in _CONTINUUM_STANDALONE_FIELD.finditer(value)
+    })
+    if standalone_fields:
+        violations.append(
+            "standalone H3 field labels: " + ", ".join(standalone_fields)
+        )
+    if _CONTINUUM_SHOT_HEADER.search(value):
+        violations.append("standalone [Shot N] wrapper")
+    if _CONTINUUM_ALIGNMENT_BOILERPLATE.search(value):
+        violations.append("standalone keyframe-alignment boilerplate")
+    if _CONTINUUM_MARKDOWN_FENCE.search(value):
+        violations.append("Markdown code fence")
+    return violations
+
+
+class ContinuumError(ValueError):
+    def __init__(self, code: str, message: str, details: Any = None):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.details = details
+
+
+def generation_target(body: dict[str, Any]) -> str:
+    value = body.get("generation_target", GENERATION_TARGET_SINGLE)
+    if value not in {GENERATION_TARGET_SINGLE, GENERATION_TARGET_CONTINUUM}:
+        raise ContinuumError(
+            "INVALID_GENERATION_TARGET",
+            "Generation target must be Single clip or H3 Continuum.",
+            {"generation_target": value},
+        )
+    return value
+
+
+def validate_continuum_settings(source: dict[str, Any]) -> dict[str, Any]:
+    value = source.get("continuum") if "continuum" in source else source
+    if not isinstance(value, dict):
+        raise ContinuumError("INVALID_CONTINUUM_SETTINGS", "H3 Continuum settings must be a JSON object.")
+    schema_version = value.get("schema_version", CONTINUUM_SCHEMA_VERSION)
+    if schema_version not in {LEGACY_CONTINUUM_SCHEMA_VERSION, CONTINUUM_SCHEMA_VERSION}:
+        raise ContinuumError(
+            "UNSUPPORTED_CONTINUUM_SCHEMA",
+            f"Unsupported H3 Continuum schema {schema_version}; expected {CONTINUUM_SCHEMA_VERSION}.",
+        )
+    chunks = value.get("chunks")
+    if not isinstance(chunks, int) or isinstance(chunks, bool) or not MIN_CHUNKS <= chunks <= MAX_CHUNKS:
+        raise ContinuumError(
+            "INVALID_CONTINUUM_CHUNKS",
+            f"H3 Continuum chunks must be an integer between {MIN_CHUNKS} and {MAX_CHUNKS}.",
+            {"chunks": chunks},
+        )
+    chunk_seconds = value.get("chunk_seconds")
+    if (
+        not isinstance(chunk_seconds, (int, float))
+        or isinstance(chunk_seconds, bool)
+        or not MIN_CHUNK_SECONDS <= float(chunk_seconds) <= MAX_CHUNK_SECONDS
+    ):
+        raise ContinuumError(
+            "INVALID_CONTINUUM_DURATION",
+            f"H3 Continuum chunk duration must be between {MIN_CHUNK_SECONDS:g} and {MAX_CHUNK_SECONDS:g} seconds.",
+            {"chunk_seconds": chunk_seconds},
+        )
+    return {
+        "schema_version": CONTINUUM_SCHEMA_VERSION,
+        "chunks": chunks,
+        "chunk_seconds": float(chunk_seconds),
+        "total_seconds": float(Decimal(str(chunk_seconds)) * chunks),
+    }
+
+
+def _normalize_inventory_from_input(request_input: dict[str, Any]) -> dict[str, Any] | None:
+    if "downstream_reference_inventory" not in request_input:
+        return None
+    try:
+        return normalize_downstream_reference_inventory(request_input.get("downstream_reference_inventory"))
+    except ValueError as error:
+        raise ContinuumError("INVALID_DOWNSTREAM_REFERENCE_INVENTORY", str(error)) from error
+
+
+def normalized_downstream_inventory(value: Any) -> dict[str, Any]:
+    try:
+        return normalize_downstream_reference_inventory(value)
+    except ValueError as error:
+        raise ContinuumError("INVALID_DOWNSTREAM_REFERENCE_INVENTORY", str(error)) from error
+
+
+def downstream_inventory_identity(value: Any) -> dict[str, Any]:
+    normalized = normalized_downstream_inventory(value)
+    fields = (
+        "role",
+        "kind",
+        "source",
+        "tag",
+        "input_name",
+        "source_node_id",
+        "source_node_class",
+        "source_output_name",
+        "source_identity",
+        "model_asset_id",
+    )
+    items = []
+    for item in normalized["items"]:
+        identity = {
+            field: (None if item.get(field) is None else str(item.get(field)))
+            for field in fields
+        }
+        identity["visible_to_model"] = bool(item.get("visible_to_model"))
+        identity["source_slot"] = item.get("source_slot")
+        items.append(identity)
+    return {
+        "schema_version": normalized["schema_version"],
+        "items": items,
+    }
+
+
+def _saved_downstream_inventory_matches(
+    saved_inventory: dict[str, Any],
+    active_inventory: dict[str, Any],
+) -> bool:
+    saved_identity = downstream_inventory_identity(saved_inventory)
+    active_identity = downstream_inventory_identity(active_inventory)
+    if saved_identity["schema_version"] != active_identity["schema_version"]:
+        return False
+    if len(saved_identity["items"]) != len(active_identity["items"]):
+        return False
+
+    for saved_item, active_item in zip(saved_identity["items"], active_identity["items"]):
+        saved_item = dict(saved_item)
+        active_item = dict(active_item)
+        saved_source_identity = saved_item.pop("source_identity", None)
+        active_source_identity = active_item.pop("source_identity", None)
+        saved_model_asset_id = saved_item.pop("model_asset_id", None)
+        active_model_asset_id = active_item.pop("model_asset_id", None)
+        if saved_item != active_item:
+            return False
+        # Snapshots created before source_identity existed are accepted once as
+        # an unknown legacy identity. A saved fingerprint, however, is strict:
+        # the active source must expose the same fingerprint.
+        if saved_source_identity is not None and saved_source_identity != active_source_identity:
+            return False
+        # model_asset_id names a temporary Prompt Writer session asset rather
+        # than the downstream source. Permit a new ID only when an existing
+        # stable source fingerprint proves that both copies came from the same
+        # workflow image. Legacy/unfingerprinted visible bindings remain strict.
+        if (
+            saved_model_asset_id != active_model_asset_id
+            and (
+                saved_source_identity is None
+                or saved_source_identity != active_source_identity
+            )
+        ):
+            return False
+    return True
+
+
+def validate_saved_downstream_inventory(
+    saved_inventory: Any,
+    active_inventory: Any,
+) -> dict[str, Any]:
+    active = normalized_downstream_inventory(active_inventory)
+    if saved_inventory is None:
+        return active
+    saved = normalized_downstream_inventory(saved_inventory)
+    if not _saved_downstream_inventory_matches(saved, active):
+        raise ContinuumError(
+            "CONTINUUM_REFERENCE_SOURCE_DRIFT",
+            (
+                "The selected H3 Continuum sampler conditioning inventory changed since this Continuum sequence was generated. "
+                "Regenerate the sequence so its reference and keyframe semantics are planned against the active workflow."
+            ),
+            {
+                "saved_inventory": saved,
+                "active_inventory": active,
+            },
+        )
+    # Return the active normalized snapshot so a successful refinement upgrades
+    # legacy pre-fingerprint inventories and future shelf replacements become strict.
+    return active
+
+
+def _stable_reference_inventory(request_input: dict[str, Any]) -> list[dict[str, Any]]:
+    downstream = _normalize_inventory_from_input(request_input)
+    if downstream is not None:
+        return [
+            {
+                **({"tag": str(item["tag"])} if item.get("tag") else {}),
+                "kind": str(item["kind"]),
+                "source": str(item["source"]),
+                "visible_to_model": bool(item["visible_to_model"]),
+                "role": str(item["role"]),
+                **({"input_name": str(item["input_name"])} if item.get("input_name") else {}),
+            }
+            for item in downstream["items"]
+        ]
+    return [
+        {
+            "tag": str(asset["reference"]),
+            "kind": str(asset["type"]),
+            "source": "prompt_writer_media",
+            "visible_to_model": asset.get("type") != "audio",
+            "role": "model_visible_media",
+        }
+        for asset in request_input.get("media_manifest", {}).get("assets", [])
+        if asset.get("reference")
+    ]
+
+
+def continuum_temporal_topology(request_input: dict[str, Any]) -> dict[str, Any]:
+    inventory = _normalize_inventory_from_input(request_input)
+    items = inventory["items"] if inventory is not None else []
+    return {
+        "first_frame": any(item["role"] == "first_frame" for item in items),
+        "last_frame": any(item["role"] == "last_frame" for item in items),
+        "reference_images": sum(1 for item in items if item["role"] == "reference_image"),
+    }
+
+
+def validate_continuum_mode_topology(mode: str, request_input: dict[str, Any]) -> None:
+    topology = continuum_temporal_topology(request_input)
+    if mode == "Reference":
+        return
+    expected = {
+        "T2VA": (False, False),
+        "I2VA": (True, False),
+        "FL2VA": (True, True),
+        "L2VA": (False, True),
+    }
+    if mode not in expected:
+        raise ContinuumError(
+            "INVALID_MODE",
+            "The selected MiniMax H3 mode is not supported by H3 Continuum.",
+            {"mode": mode},
+        )
+    actual = (topology["first_frame"], topology["last_frame"])
+    required = expected[mode]
+    reference_mode_mismatch = mode == "T2VA" and int(topology["reference_images"]) > 0
+    if actual != required or reference_mode_mismatch:
+        labels = {
+            (False, False): "no First/Last keyframes",
+            (True, False): "First Frame only",
+            (True, True): "First Frame and Last Frame",
+            (False, True): "Last Frame only",
+        }
+        if reference_mode_mismatch:
+            message = (
+                "T2VA does not match the selected H3 Continuum sampler conditioning. T2VA requires no First/Last "
+                f"keyframes and no Reference Images, but the sampler has {int(topology['reference_images'])} active "
+                "Reference Image input(s). Use Reference mode, or remove the Reference Images."
+            )
+        else:
+            message = (
+                f"{mode} does not match the selected H3 Continuum sampler's temporal keyframe wiring. "
+                f"{mode} requires {labels[required]}, but the sampler currently has {labels[actual]}."
+            )
+        raise ContinuumError(
+            "CONTINUUM_MODE_TOPOLOGY_MISMATCH",
+            message,
+            {
+                "mode": mode,
+                "required": {
+                    "first_frame": required[0],
+                    "last_frame": required[1],
+                    **({"reference_images": 0} if mode == "T2VA" else {}),
+                },
+                "actual": topology,
+            },
+        )
+
+
+def stable_reference_tags(request_input: dict[str, Any]) -> set[str]:
+    return {
+        str(item["tag"])
+        for item in _stable_reference_inventory(request_input)
+        if item.get("tag")
+    }
+
+
+def persistent_reference_tags(request_input: dict[str, Any], *, chunks: int) -> set[str]:
+    inventory = _normalize_inventory_from_input(request_input)
+    if inventory is None:
+        return stable_reference_tags(request_input)
+    tagged = [item for item in inventory["items"] if item.get("tag")]
+    if int(chunks) == 1:
+        return {str(item["tag"]) for item in tagged}
+    return {
+        str(item["tag"])
+        for item in tagged
+        if item["role"] in {"reference_image", "video_reference", "reference_audio"}
+    }
+
+
+def chunk_reference_tags(
+    request_input: dict[str, Any],
+    *,
+    chunk_index: int,
+    chunks: int,
+) -> set[str]:
+    if not 1 <= int(chunk_index) <= int(chunks):
+        raise ContinuumError(
+            "INVALID_CONTINUUM_CHUNK",
+            "Chunk reference scope requires a valid one-based chunk index.",
+            {"chunk_index": chunk_index, "chunks": chunks},
+        )
+    inventory = _normalize_inventory_from_input(request_input)
+    if inventory is None:
+        return stable_reference_tags(request_input)
+    allowed: set[str] = set()
+    for item in inventory["items"]:
+        tag = item.get("tag")
+        if not tag:
+            continue
+        role = item["role"]
+        if role in {"reference_image", "video_reference", "reference_audio"}:
+            allowed.add(str(tag))
+        elif role == "first_frame" and int(chunk_index) == 1:
+            allowed.add(str(tag))
+        elif role == "last_frame" and int(chunk_index) == int(chunks):
+            allowed.add(str(tag))
+    return allowed
+
+
+def sequence_reference_scopes(
+    request_input: dict[str, Any],
+    *,
+    chunks: int,
+) -> list[set[str]]:
+    return [
+        chunk_reference_tags(
+            request_input,
+            chunk_index=index,
+            chunks=chunks,
+        )
+        for index in range(1, int(chunks) + 1)
+    ]
+
+
+def validate_sequence_reference_scope(
+    request_input: dict[str, Any],
+    *,
+    preamble: str,
+    prompts: list[str],
+    chunks: int,
+) -> None:
+    if len(prompts) != int(chunks):
+        raise ContinuumError(
+            "INVALID_CONTINUUM_SEQUENCE",
+            "Continuum reference-scope validation requires exactly one prompt body per configured chunk.",
+            {"expected": int(chunks), "actual": len(prompts)},
+        )
+
+    expected = stable_reference_tags(request_input)
+    persistent = persistent_reference_tags(request_input, chunks=chunks)
+    scopes = sequence_reference_scopes(request_input, chunks=chunks)
+
+    preamble_references = reference_tags(str(preamble or ""))
+    undeclared_global = preamble_references - expected
+    if undeclared_global:
+        raise ContinuumError(
+            "CONTINUUM_REFERENCE_IDENTITY_DRIFT",
+            "The edited Continuum preamble contains public reference labels outside the selected downstream inventory.",
+            {
+                "scope": "global",
+                "unexpected": sorted(undeclared_global),
+                "allowed": sorted(expected),
+            },
+        )
+    scoped_global = preamble_references - persistent
+    if scoped_global:
+        raise ContinuumError(
+            "CONTINUUM_REFERENCE_SCOPE_DRIFT",
+            "The edited Continuum preamble uses a public reference that is not persistent across every chunk.",
+            {
+                "scope": "global",
+                "unexpected": sorted(scoped_global),
+                "persistent": sorted(persistent),
+            },
+        )
+
+    for index, prompt in enumerate(prompts, start=1):
+        prompt_references = reference_tags(str(prompt or ""))
+        undeclared = prompt_references - expected
+        if undeclared:
+            raise ContinuumError(
+                "CONTINUUM_REFERENCE_IDENTITY_DRIFT",
+                f"Edited Continuum Chunk {index} contains public reference labels outside the selected downstream inventory.",
+                {
+                    "scope": "chunk",
+                    "chunk_index": index,
+                    "unexpected": sorted(undeclared),
+                    "allowed": sorted(expected),
+                },
+            )
+        allowed = scopes[index - 1]
+        scoped = prompt_references - allowed
+        if scoped:
+            raise ContinuumError(
+                "CONTINUUM_REFERENCE_SCOPE_DRIFT",
+                f"Edited Continuum Chunk {index} uses a public reference outside that chunk's downstream conditioning scope.",
+                {
+                    "scope": "chunk",
+                    "chunk_index": index,
+                    "unexpected": sorted(scoped),
+                    "allowed": sorted(allowed),
+                },
+            )
+
+
+def _planner_schema(settings: dict[str, Any]) -> str:
+    chunk_template = [
+        {
+            "continuity": "initial" if index == 1 else "continuous",
+            "transition": "",
+            "start_state": "compact state at the start of this chunk",
+            "action": "events that happen during this chunk",
+            "end_state": "compact state reached at the end of this chunk",
+        }
+        for index in range(1, settings["chunks"] + 1)
+    ]
+    return json.dumps(
+        {
+            "schema_version": CONTINUUM_SCHEMA_VERSION,
+            "global": {
+                "sequence_preamble": (
+                    "Polished MiniMax H3 prompt prose containing only sequence-wide identity, persistent reference roles, "
+                    "wardrobe/prop/environment/style continuity, genuinely global camera/lighting/audio rules, exclusions, "
+                    "and other constraints intended to apply to every chunk."
+                ),
+                "continuity_anchors": "compact internal continuity facts used while planning",
+                "persistent_constraints": "compact internal constraints that apply across the sequence",
+                "subject_anchors": [
+                    {
+                        "id": "<Subject 1>",
+                        "meaning": "stable identity and role of this subject across chunks",
+                    }
+                ],
+            },
+            "chunks": chunk_template,
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
+
+
+CONTINUUM_PLAN_SYSTEM_PROMPT = """Plan one coherent MiniMax H3 Continuum sequence and return one JSON object with no Markdown fence or commentary. The application owns chunk count, time boundaries, public reference numbering, and output serialization; do not reproduce those values as bookkeeping fields. The global.sequence_preamble is the common Continuum prompt text that will be prepended verbatim to every logical chunk. It must contain only facts and instructions that truly persist across every chunk: stable subject identity and appearance, stable speaker/voice identity when vocalization recurs, persistent Reference Image or Video Reference roles, wardrobe/prop/environment/style continuity, genuinely global camera/lighting/audio rules, exclusions, and temporal-continuity constraints. Public Reference Images and <Video 1> are persistent when present. A public First Frame <Picture N> identity is opening-chunk-only in a multi-chunk sequence; a public Last Frame <Picture N> identity is final-chunk-only; neither may appear in the shared preamble unless the sequence has only one chunk. Driving Audio is persistent conditioning and owns no <Audio N> prompt tag. Do not place chunk-local action, dialogue, later-shot changes, or a final-frame target in the shared preamble when they do not apply to every chunk. Internal planning fields continuity_anchors and persistent_constraints are required text fields but may be empty when there is genuinely no additional sequence-wide planning fact or constraint beyond sequence_preamble and the chunk states; otherwise keep them compact and semantic. Each chunk's start/action/end state remains required non-empty semantic text rather than final-prompt meta. Preserve the user's explicit dialogue and lyrics verbatim, visible text verbatim, reference semantics, exclusions, camera rules, sound rules, and intended ending. Treat explicitly assigned reference roles as exclusive: do not transfer unrelated identity, clothing, setting, lighting, camera, motion, or audio traits from a source unless the user asks for them. Do not infer dialogue, lyrics, a transcript, or exact audio content from Driving Audio or any other conditioning that is not visible/audible to the prompt model. A later chunk continues from the previous end_state unless continuity is intentional_break. Use intentional_break only for a requested cut, location/time/wardrobe change, entrance/exit, camera reset, major framing change, or another deliberate discontinuity, and explain it in transition. Do not emit reference_assignments: Prompt Writer injects authoritative downstream H3 public reference identities. subject_anchors must be [] when no stable subject identity is needed; otherwise every entry is exactly {"id":"<Subject N>","meaning":"concise stable identity and role"}. Never emit bare strings in subject_anchors and never reuse one subject id for a different entity. Before returning, silently verify the complete JSON contract: global.sequence_preamble is non-empty polished prompt prose; continuity_anchors and persistent_constraints are text; subject_anchors is [] or uses positive numeric IDs exactly like <Subject 1>, <Subject 2>; the chunk array has the exact requested length; Chunk 1 continuity is initial; later continuity is continuous or intentional_break with a non-empty transition; every start_state/action/end_state is non-empty; and no application-owned index, time, chunk-count, or reference_assignments field is present."""
+
+
+def _preflight_body_references(base_input: dict[str, Any], texts: list[str]) -> None:
+    missing = missing_reference_declarations(base_input, texts, continuum=True)
+    if missing:
+        tag = missing[0]
+        raise ContinuumError(
+            "REFERENCE_NOT_DECLARED",
+            f"{tag} is used by the Continuum request but is not declared by the selected H3 Continuum sampler inventory.",
+            {"reference": tag, "missing": missing},
+        )
+
+
+def assemble_continuum_plan_request(body: dict[str, Any]) -> dict[str, Any]:
+    if body.get("mode") == "Music3":
+        raise ContinuumError("CONTINUUM_MUSIC_UNSUPPORTED", "H3 Continuum is available only for H3 Video.")
+    if not isinstance(body.get("downstream_reference_inventory"), dict):
+        raise ContinuumError(
+            "INVALID_DOWNSTREAM_REFERENCE_INVENTORY",
+            "H3 Continuum requires the authoritative downstream conditioning inventory from the selected H3 Continuum sampler.",
+            {
+                "field": "downstream_reference_inventory",
+                "suggestion": (
+                    "Select one supported H3 Continuum sampler and retry. An explicitly empty inventory is valid "
+                    "when that sampler has no active reference, keyframe, Video Reference, or Driving Audio inputs."
+                ),
+            },
+        )
+    settings = validate_continuum_settings(body)
+    single_body = dict(body)
+    single_body["duration_seconds"] = settings["chunk_seconds"]
+    single_body["generation_target"] = GENERATION_TARGET_CONTINUUM
+    base = assemble_request(single_body)
+    validate_continuum_mode_topology(str(body.get("mode") or ""), base["input"])
+    _preflight_body_references(base["input"], [base["input"]["creative_brief"]])
+    references = _stable_reference_inventory(base["input"])
+    role_labels = {
+        "reference_image": "Reference Image",
+        "first_frame": "First Frame keyframe",
+        "last_frame": "Last Frame keyframe",
+        "video_reference": "Video Reference",
+        "reference_audio": "Reference Audio",
+        "driving_audio": "Driving Audio",
+    }
+    reference_lines = "\n".join(
+        (
+            f"- {item.get('tag') or role_labels.get(item['role'], item['role'])}: "
+            f"downstream {item['role']} conditioning"
+            + (f" via {item['input_name']}" if item.get("input_name") else "")
+            + f" (visible to planner: {'yes' if item['visible_to_model'] else 'no'})"
+        )
+        for item in references
+    ) or "- None"
+    user = (
+        f"Underlying H3 mode: {body['mode']}\n"
+        f"Sequence consists of {settings['chunks']} consecutive chunks, each {settings['chunk_seconds']:g} seconds.\n"
+        f"Total sequence duration: {settings['total_seconds']:g} seconds.\n\n"
+        f"Authoritative downstream H3 conditioning inventory:\n{reference_lines}\n\n"
+        "Every inventory entry with an explicit public tag owns that exact H3 prompt identity. Reference Images, "
+        "Video Reference, and Reference Audio are persistent across chunks. Reference Audio owns <Audio 1> when connected. "
+        "Without Reference Images, a tagged First Frame is opening-chunk-only and a tagged Last Frame is final-chunk-only; "
+        "do not place those scoped keyframe tags in the shared preamble of a multi-chunk sequence. Driving Audio is "
+        "persistent conditioning and owns no <Audio N> tag. Any item marked not "
+        "visible to the planner exists downstream but its pixels or signal were not supplied here; preserve only roles "
+        "stated by the Creative Brief and do not invent unseen content.\n\n"
+        f"Creative brief:\n{base['input']['creative_brief']}\n\n"
+        "Return exactly the semantic schema below. Do not add chunk index/time fields or reference_assignments; "
+        "Prompt Writer owns those deterministic values.\n\n"
+        f"Schema:\n{_planner_schema(settings)}"
+    )
+    return {
+        "schema_version": 1,
+        "guide": {"id": "h3-continuum-plan-v2", "title": "H3 Continuum sequence plan"},
+        "input": {
+            **base["input"],
+            "mode": "T2VA",
+            "underlying_mode": body["mode"],
+            "generation_target": GENERATION_TARGET_CONTINUUM,
+            "continuum_stage": "plan",
+            "continuum": settings,
+        },
+        "media_inputs": base["media_inputs"],
+        "supporting_guides": [],
+        "system_prompt": {"custom": False, "content": CONTINUUM_PLAN_SYSTEM_PROMPT},
+        "messages": [
+            {"role": "system", "name": "h3_continuum_sequence_planner", "content": CONTINUUM_PLAN_SYSTEM_PROMPT},
+            {"role": "user", "content": user},
+        ],
+    }
+
+
+def _json_object(text: str) -> dict[str, Any]:
+    value = text.strip()
+    match = _FENCE.fullmatch(value)
+    if match:
+        value = match.group(1).strip()
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as error:
+        raise ContinuumError(
+            "INVALID_CONTINUUM_PLAN",
+            "The sequence planner did not return valid JSON.",
+            {"line": error.lineno, "column": error.colno, "reason": error.msg},
+        ) from error
+    if not isinstance(parsed, dict):
+        raise ContinuumError("INVALID_CONTINUUM_PLAN", "The sequence plan must be a JSON object.")
+    return parsed
+
+
+def _embedded_plan_json_object(text: str) -> dict[str, Any] | None:
+    value = str(text or "").strip()
+    if not value:
+        return None
+    decoder = json.JSONDecoder()
+    candidates: list[tuple[int, int, dict[str, Any]]] = []
+    for offset, char in enumerate(value):
+        if char != "{":
+            continue
+        try:
+            parsed, consumed = decoder.raw_decode(value[offset:])
+        except json.JSONDecodeError:
+            continue
+        if (
+            isinstance(parsed, dict)
+            and isinstance(parsed.get("global"), dict)
+            and isinstance(parsed.get("chunks"), list)
+        ):
+            candidates.append((offset, offset + consumed, parsed))
+    unique_spans = {(start, end) for start, end, _parsed in candidates}
+    if len(unique_spans) != 1:
+        return None
+    return candidates[0][2]
+
+
+def _punctuated_sentence(value: str) -> str:
+    text = " ".join(str(value or "").split()).strip()
+    if not text:
+        return ""
+    return text if text[-1] in ".!?" else text + "."
+
+
+def _fallback_sequence_preamble(
+    global_plan: dict[str, Any],
+    *,
+    persistent_references: set[str],
+) -> str:
+    parts: list[str] = []
+    subjects = global_plan.get("subject_anchors")
+    if isinstance(subjects, list):
+        for subject in subjects:
+            if not isinstance(subject, dict):
+                continue
+            meaning = subject.get("meaning")
+            if isinstance(meaning, str) and meaning.strip():
+                parts.append(meaning.strip())
+    for field in ("continuity_anchors", "persistent_constraints"):
+        value = global_plan.get(field)
+        if isinstance(value, str) and value.strip():
+            parts.append(value.strip())
+    if persistent_references:
+        tags = ", ".join(sorted(persistent_references))
+        parts.append(
+            f"Persistent reference identities {tags} retain their established roles throughout the sequence"
+        )
+
+    rendered: list[str] = []
+    seen: set[str] = set()
+    for part in parts:
+        sentence = _punctuated_sentence(part)
+        key = sentence.casefold()
+        if sentence and key not in seen:
+            rendered.append(sentence)
+            seen.add(key)
+    if rendered:
+        return " ".join(rendered)
+    return (
+        "Maintain coherent visual and temporal continuity across the sequence while preserving only established "
+        "persistent details and honoring any intentional transition."
+    )
+
+
+def recover_sequence_plan_contract(
+    text: str,
+    settings: dict[str, Any],
+    *,
+    expected_references: set[str],
+    persistent_references: set[str] | None = None,
+    chunk_reference_scopes: list[set[str]] | None = None,
+) -> tuple[dict[str, Any], list[str]]:
+    actions: list[str] = []
+    try:
+        raw_plan = _json_object(text)
+    except ContinuumError as strict_json_error:
+        raw_plan = _embedded_plan_json_object(text)
+        if raw_plan is None:
+            raise strict_json_error
+        actions.append("extracted_embedded_json")
+
+    candidate = copy.deepcopy(raw_plan)
+    if candidate.get("schema_version") != CONTINUUM_SCHEMA_VERSION:
+        return (
+            validate_sequence_plan(
+                candidate,
+                settings,
+                expected_references=expected_references,
+                persistent_references=persistent_references,
+                chunk_reference_scopes=chunk_reference_scopes,
+                allow_legacy=False,
+            ),
+            actions,
+        )
+
+    global_plan = candidate.get("global")
+    if isinstance(global_plan, dict):
+        for field in ("continuity_anchors", "persistent_constraints"):
+            if global_plan.get(field) is None:
+                global_plan[field] = ""
+                actions.append(f"defaulted_{field}")
+        if global_plan.get("subject_anchors") is None:
+            global_plan["subject_anchors"] = []
+            actions.append("defaulted_subject_anchors")
+        if "reference_assignments" in global_plan:
+            global_plan.pop("reference_assignments", None)
+            actions.append("removed_reference_assignments")
+        sequence_preamble = global_plan.get("sequence_preamble")
+        if not isinstance(sequence_preamble, str) or not sequence_preamble.strip():
+            global_plan["sequence_preamble"] = _fallback_sequence_preamble(
+                global_plan,
+                persistent_references=set(persistent_references or set()),
+            )
+            actions.append("synthesized_sequence_preamble")
+
+    chunks = candidate.get("chunks")
+    if isinstance(chunks, list):
+        removed_index = False
+        for chunk in chunks:
+            if isinstance(chunk, dict) and "index" in chunk:
+                chunk.pop("index", None)
+                removed_index = True
+        if removed_index:
+            actions.append("removed_chunk_indexes")
+
+    normalized = validate_sequence_plan(
+        candidate,
+        settings,
+        expected_references=expected_references,
+        persistent_references=persistent_references,
+        chunk_reference_scopes=chunk_reference_scopes,
+        allow_legacy=False,
+    )
+    return normalized, actions
+
+
+def _nonempty_string(value: Any, field: str, *, chunk_index: int | None = None) -> str:
+    if not isinstance(value, str) or not value.strip():
+        details = {"field": field}
+        if chunk_index is not None:
+            details["chunk_index"] = chunk_index
+        raise ContinuumError("INVALID_CONTINUUM_PLAN", f"Sequence-plan {field} must be non-empty text.", details)
+    return value.strip()
+
+
+def _text_string(value: Any, field: str) -> str:
+    if not isinstance(value, str):
+        raise ContinuumError(
+            "INVALID_CONTINUUM_PLAN",
+            f"Sequence-plan {field} must be text.",
+            {"field": field},
+        )
+    return value.strip()
+
+
+def _canonical_subject_id(value: Any) -> str:
+    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+        return f"<Subject {value}>"
+    if not isinstance(value, str) or not value.strip():
+        raise ContinuumError(
+            "INVALID_CONTINUUM_PLAN",
+            "Sequence-plan subject_anchors.id must identify a positive subject number.",
+            {"field": "subject_anchors.id"},
+        )
+    raw = value.strip()
+    alias_match = _SUBJECT_ALPHA_ALIAS_TAG.fullmatch(raw)
+    if alias_match:
+        return f"<Subject {_subject_alpha_alias_number(alias_match.group(1))}>"
+    patterns = (
+        r"<\s*Subject\s+([1-9]\d*)\s*>",
+        r"Subject\s+([1-9]\d*)",
+        r"S(?:ubject)?[_-]?([1-9]\d*)",
+        r"([1-9]\d*)",
+    )
+    for pattern in patterns:
+        match = re.fullmatch(pattern, raw, re.IGNORECASE)
+        if match:
+            return f"<Subject {int(match.group(1))}>"
+    raise ContinuumError(
+        "INVALID_CONTINUUM_PLAN",
+        f"Invalid stable subject id: {raw}.",
+        {
+            "field": "subject_anchors.id",
+            "expected": "<Subject N> with a positive numeric N",
+        },
+    )
+
+
+def validate_sequence_plan(
+    plan: dict[str, Any],
+    settings: dict[str, Any],
+    *,
+    expected_references: set[str],
+    persistent_references: set[str] | None = None,
+    chunk_reference_scopes: list[set[str]] | None = None,
+    allow_legacy: bool = False,
+    allow_application_owned_fields: bool = False,
+) -> dict[str, Any]:
+    schema_version = plan.get("schema_version")
+    if schema_version != CONTINUUM_SCHEMA_VERSION:
+        if not (allow_legacy and schema_version == LEGACY_CONTINUUM_SCHEMA_VERSION):
+            raise ContinuumError(
+                "INVALID_CONTINUUM_PLAN",
+                f"Sequence-plan schema_version must be {CONTINUUM_SCHEMA_VERSION}.",
+            )
+    global_plan = plan.get("global")
+    if not isinstance(global_plan, dict):
+        raise ContinuumError("INVALID_CONTINUUM_PLAN", "Sequence-plan global must be an object.")
+    continuity_anchors = _normalize_plan_subject_aliases(
+        _text_string(global_plan.get("continuity_anchors"), "global.continuity_anchors")
+    )
+    persistent_constraints = _normalize_plan_subject_aliases(
+        _text_string(global_plan.get("persistent_constraints"), "global.persistent_constraints")
+    )
+    if schema_version == LEGACY_CONTINUUM_SCHEMA_VERSION:
+        sequence_preamble = ""
+    else:
+        sequence_preamble = _normalize_plan_subject_aliases(
+            _nonempty_string(global_plan.get("sequence_preamble"), "global.sequence_preamble")
+        )
+        if _contains_reserved_sequence_header(sequence_preamble):
+            raise ContinuumError(
+                "INVALID_CONTINUUM_PLAN",
+                "The sequence-wide preamble cannot contain Continuum timeline or legacy chunk headers.",
+                {"field": "global.sequence_preamble"},
+            )
+    normalized_assignments = [
+        {
+            "tag": tag,
+            "role": "Preserve this exact downstream H3 public reference identity and its application-owned scope.",
+        }
+        for tag in sorted(expected_references)
+    ]
+    subject_anchors = global_plan.get("subject_anchors", [])
+    if not isinstance(subject_anchors, list):
+        raise ContinuumError("INVALID_CONTINUUM_PLAN", "Sequence-plan subject_anchors must be a list.")
+    normalized_subjects = []
+    seen_subjects: set[str] = set()
+    for subject in subject_anchors:
+        if not isinstance(subject, dict):
+            raise ContinuumError("INVALID_CONTINUUM_PLAN", "Every subject anchor must be an object.")
+        canonical_id = _canonical_subject_id(subject.get("id"))
+        meaning = _normalize_plan_subject_aliases(
+            _nonempty_string(subject.get("meaning"), "subject_anchors.meaning")
+        )
+        if canonical_id in seen_subjects:
+            raise ContinuumError("INVALID_CONTINUUM_PLAN", f"Sequence plan defines {canonical_id} more than once.")
+        seen_subjects.add(canonical_id)
+        normalized_subjects.append({"id": canonical_id, "meaning": meaning})
+
+    chunks = plan.get("chunks")
+    if not isinstance(chunks, list) or len(chunks) != settings["chunks"]:
+        raise ContinuumError(
+            "INVALID_CONTINUUM_PLAN_CHUNKS",
+            "Sequence-plan chunk count does not match the requested chunk count.",
+            {"expected": settings["chunks"], "actual": len(chunks) if isinstance(chunks, list) else None},
+        )
+    global_reference_texts = [
+        sequence_preamble,
+        continuity_anchors,
+        persistent_constraints,
+        *(item["meaning"] for item in normalized_subjects),
+    ]
+    global_references: set[str] = set()
+    global_subjects: set[str] = set()
+    for text_value in global_reference_texts:
+        global_references.update(reference_tags(text_value))
+        global_subjects.update(subject_tags(text_value))
+
+    normalized_chunks = []
+    chunk_references: list[set[str]] = []
+    chunk_subjects: list[set[str]] = []
+    for index, chunk in enumerate(chunks, start=1):
+        if not isinstance(chunk, dict):
+            raise ContinuumError("INVALID_CONTINUUM_PLAN", f"Sequence-plan Chunk {index} must be an object.")
+        if schema_version == LEGACY_CONTINUUM_SCHEMA_VERSION:
+            legacy_index = chunk.get("index")
+            if legacy_index != index:
+                raise ContinuumError(
+                    "INVALID_CONTINUUM_PLAN_CHUNKS",
+                    "Legacy sequence-plan chunk indexes must be contiguous and one-based.",
+                    {"expected": index, "actual": legacy_index},
+                )
+        elif "index" in chunk:
+            if not allow_application_owned_fields:
+                raise ContinuumError(
+                    "INVALID_CONTINUUM_PLAN",
+                    "Sequence planner must not emit application-owned chunk index fields.",
+                    {"chunk_index": index, "field": "index"},
+                )
+            if chunk.get("index") != index:
+                raise ContinuumError(
+                    "INVALID_CONTINUUM_PLAN_CHUNKS",
+                    "Application-normalized sequence-plan chunk indexes must remain contiguous and one-based.",
+                    {"expected": index, "actual": chunk.get("index")},
+                )
+        continuity = chunk.get("continuity")
+        allowed = {"initial"} if index == 1 else {"continuous", "intentional_break"}
+        if continuity not in allowed:
+            raise ContinuumError(
+                "INVALID_CONTINUUM_PLAN_CONTINUITY",
+                f"Chunk {index} continuity must be one of: {', '.join(sorted(allowed))}.",
+            )
+        transition = chunk.get("transition", "")
+        if not isinstance(transition, str):
+            raise ContinuumError("INVALID_CONTINUUM_PLAN", f"Chunk {index} transition must be text.")
+        transition = _normalize_plan_subject_aliases(transition.strip())
+        if continuity == "intentional_break" and not transition:
+            raise ContinuumError(
+                "INVALID_CONTINUUM_PLAN_CONTINUITY",
+                f"Chunk {index} must explain its intentional continuity break.",
+            )
+        normalized_chunk = {
+            "index": index,
+            "continuity": continuity,
+            "transition": transition,
+            "start_state": _normalize_plan_subject_aliases(
+                _nonempty_string(chunk.get("start_state"), "start_state", chunk_index=index)
+            ),
+            "action": _normalize_plan_subject_aliases(
+                _nonempty_string(chunk.get("action"), "action", chunk_index=index)
+            ),
+            "end_state": _normalize_plan_subject_aliases(
+                _nonempty_string(chunk.get("end_state"), "end_state", chunk_index=index)
+            ),
+        }
+        normalized_chunks.append(normalized_chunk)
+        references_for_chunk: set[str] = set()
+        subjects_for_chunk: set[str] = set()
+        for text_value in (
+            normalized_chunk["transition"],
+            normalized_chunk["start_state"],
+            normalized_chunk["action"],
+            normalized_chunk["end_state"],
+        ):
+            references_for_chunk.update(reference_tags(text_value))
+            subjects_for_chunk.update(subject_tags(text_value))
+        chunk_references.append(references_for_chunk)
+        chunk_subjects.append(subjects_for_chunk)
+
+    planned_subject_ids = {item["id"] for item in normalized_subjects}
+    used_subject_ids = set(global_subjects)
+    for subjects_for_chunk in chunk_subjects:
+        used_subject_ids.update(subjects_for_chunk)
+    unexpected_subjects = used_subject_ids - planned_subject_ids
+    if unexpected_subjects:
+        raise ContinuumError(
+            "CONTINUUM_SUBJECT_IDENTITY_DRIFT",
+            "The sequence plan uses subject labels that are not declared in global.subject_anchors.",
+            {
+                "unexpected": sorted(unexpected_subjects),
+                "planned": sorted(planned_subject_ids),
+            },
+        )
+
+    plan_references = set(global_references)
+    for references_for_chunk in chunk_references:
+        plan_references.update(references_for_chunk)
+    unexpected_references = plan_references - expected_references
+    if unexpected_references:
+        raise ContinuumError(
+            "CONTINUUM_REFERENCE_IDENTITY_DRIFT",
+            "The sequence plan introduced reference labels outside the declared downstream sequence inventory.",
+            {
+                "unexpected": sorted(unexpected_references),
+                "allowed": sorted(expected_references),
+            },
+        )
+
+    persistent_allowed = (
+        set(expected_references)
+        if persistent_references is None
+        else set(persistent_references)
+    )
+    scoped_global_references = global_references - persistent_allowed
+    if scoped_global_references:
+        raise ContinuumError(
+            "CONTINUUM_REFERENCE_SCOPE_DRIFT",
+            "A sequence-wide planning field uses a public reference that is not persistent across every chunk.",
+            {
+                "scope": "global",
+                "unexpected": sorted(scoped_global_references),
+                "persistent": sorted(persistent_allowed),
+            },
+        )
+
+    if chunk_reference_scopes is not None:
+        if len(chunk_reference_scopes) != settings["chunks"]:
+            raise ContinuumError(
+                "INVALID_CONTINUUM_PLAN",
+                "Internal chunk reference scope count does not match the sequence chunk count.",
+                {
+                    "expected": settings["chunks"],
+                    "actual": len(chunk_reference_scopes),
+                },
+            )
+        for index, references_for_chunk in enumerate(chunk_references, start=1):
+            allowed_for_chunk = set(chunk_reference_scopes[index - 1])
+            scoped_chunk_references = references_for_chunk - allowed_for_chunk
+            if scoped_chunk_references:
+                raise ContinuumError(
+                    "CONTINUUM_REFERENCE_SCOPE_DRIFT",
+                    f"Sequence-plan Chunk {index} uses a public reference outside that chunk's downstream conditioning scope.",
+                    {
+                        "scope": "chunk",
+                        "chunk_index": index,
+                        "unexpected": sorted(scoped_chunk_references),
+                        "allowed": sorted(allowed_for_chunk),
+                    },
+                )
+
+    return {
+        "schema_version": CONTINUUM_SCHEMA_VERSION,
+        "global": {
+            "sequence_preamble": sequence_preamble,
+            "continuity_anchors": continuity_anchors,
+            "persistent_constraints": persistent_constraints,
+            "reference_assignments": normalized_assignments,
+            "subject_anchors": normalized_subjects,
+        },
+        "chunks": normalized_chunks,
+    }
+
+
+def parse_sequence_plan(
+    text: str,
+    settings: dict[str, Any],
+    *,
+    expected_references: set[str],
+    persistent_references: set[str] | None = None,
+    chunk_reference_scopes: list[set[str]] | None = None,
+) -> dict[str, Any]:
+    return validate_sequence_plan(
+        _json_object(text),
+        settings,
+        expected_references=expected_references,
+        persistent_references=persistent_references,
+        chunk_reference_scopes=chunk_reference_scopes,
+        allow_legacy=False,
+    )
+
+
+def assemble_continuum_plan_repair_request(
+    body: dict[str, Any],
+    invalid_text: str,
+    error: ContinuumError,
+) -> dict[str, Any]:
+    assembled = assemble_continuum_plan_request(body)
+    assembled["input"]["continuum_stage"] = "plan_repair"
+    assembled["messages"] = [
+        {
+            "role": "system",
+            "name": "h3_continuum_sequence_plan_repair",
+            "content": (
+                CONTINUUM_PLAN_SYSTEM_PROMPT
+                + "\n\nREPAIR MODE — COMPLETE CONTRACT AUDIT: The reported contract error is the first validation "
+                "failure, not necessarily the only invalid field. Audit the complete sequence plan against the exact "
+                "original schema and repair every contract violation required for the whole object to validate in this "
+                "one bounded repair pass. Preserve every already-valid creative choice and change only invalid, missing, "
+                "or structurally inconsistent contract fields. Re-check all required objects, field types, the required "
+                "non-empty global.sequence_preamble, exact chunk count and continuity values, subject anchors, public-"
+                "reference identity/scope, and application-owned field exclusions before returning one complete JSON "
+                "object with no Markdown fence or commentary. Do not add application-owned chunk indexes, time ranges, "
+                "chunk-count fields, or reference_assignments. subject_anchors must be [] or objects with exactly id and "
+                "meaning; return canonical positive numeric IDs such as <Subject 1> and <Subject 2>, never alphabetic IDs "
+                "such as <Subject A>. Do not preserve malformed contract syntax merely because its creative meaning is "
+                "otherwise valid."
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                f"First validation error: {error.message}\nDetails: {json.dumps(error.details, ensure_ascii=False)}\n\n"
+                "Repair the whole object, not only that field. The returned global.sequence_preamble must be non-empty, "
+                "and every stable subject ID must be canonical numeric <Subject N>.\n\n"
+                f"Invalid plan:\n{invalid_text}\n\n"
+                f"Original planning request:\n{assembled['messages'][-1]['content']}"
+            ),
+        },
+    ]
+    return assembled
+
+
+CONTINUUM_CHUNK_SYSTEM_PROMPT = """Write exactly one chunk-local MiniMax H3 Continuum Timeline prompt body and nothing else. This is a logical span inside a Continuum sequence, not a standalone T2VA/I2VA/FL2VA/L2VA/Reference request. Never emit standalone first/last-frame alignment boilerplate, Reference-mode six-section wrappers, integrated_multimodal_description/overall_soundscape/non_diegetic_music field labels, [Shot N] headings, a Continuum Timeline header, JSON, Markdown fencing, or planning commentary. Continuum itself owns the canonical [start-end] header, prepends the shared sequence preamble, applies continuation state, and applies First Frame, Last Frame, Reference Image, Video Reference, and Driving Audio conditioning according to the downstream workflow. Write polished production prompt prose for only this span. Every detail must be grounded in something visible or audible in the requested result: establish the local starting state only as needed, then describe visible action and state progression, camera development, exact dialogue/visible text when supplied, relevant diegetic sound and requested music behavior, and the terminal state needed for the next span. Prefer one continuous shot unless the user or semantic plan requests a cut; do not invent cuts merely to add variety. Describe camera motion naturally with the motion type and only meaningful speed/amplitude qualifiers. The outer Continuum Timeline owns absolute sequence timing, so do not write absolute sequence timestamps inside a chunk body; express internal progression locally with phrases such as at the beginning, then, midway through the span, or near the end. Speakers who vocalize use stable sequence-wide IDs such as (S1), (S2); reuse the same ID when a speaker returns in later chunks. Put only the exact user-supplied spoken or sung words inside <d>[Language] ...</d>; do not translate, paraphrase, or invent missing words. Preserve visible on-screen text verbatim in English double quotation marks. Do not invent non-diegetic music; describe it only when the user requests it. A continuous chunk must evolve from the previous accepted terminal state rather than resetting to the original opening composition. Treat every explicitly assigned reference role as exclusive: do not copy unrelated identity, clothing, setting, lighting, camera, motion, or audio traits from that source. Treat public reference tags as scoped identities: persistent Reference Images, <Video 1>, and Reference Audio <Audio 1> may recur across chunks; a public First Frame <Picture N> tag may be used only in the opening chunk; a public Last Frame <Picture N> tag may be used only in the final chunk. Driving Audio owns no <Audio N> tag. Use only the public tags explicitly listed as available for this chunk. Never invent unseen reference content, dialogue, lyrics, transcript, or exact sound details from conditioning the prompt model did not receive. Preserve stable <Subject N> meanings from the sequence plan and never create a new subject id unless it is declared there."""
+
+
+def _reference_scope_lines(
+    request_input: dict[str, Any],
+    *,
+    chunk_index: int,
+    chunks: int,
+) -> str:
+    allowed = chunk_reference_tags(
+        request_input,
+        chunk_index=chunk_index,
+        chunks=chunks,
+    )
+    lines: list[str] = []
+    role_labels = {
+        "reference_image": "Reference Image",
+        "first_frame": "First Frame",
+        "last_frame": "Last Frame",
+        "video_reference": "Video Reference",
+        "reference_audio": "Reference Audio",
+        "driving_audio": "Driving Audio",
+        "model_visible_media": "Prompt Writer analysis media",
+    }
+    for item in _stable_reference_inventory(request_input):
+        role = item["role"]
+        tag = item.get("tag")
+        if role in {"reference_image", "video_reference", "reference_audio"}:
+            scope = "persistent across all chunks"
+        elif role == "first_frame":
+            scope = "opening chunk only"
+        elif role == "last_frame":
+            scope = "final chunk only"
+        elif role == "driving_audio":
+            scope = "persistent conditioning; no public prompt tag"
+        else:
+            scope = "analysis-only identity"
+        availability = (
+            "available in this chunk"
+            if tag and str(tag) in allowed
+            else "not a public tag in this chunk"
+        )
+        visible = "visible to prompt model" if item.get("visible_to_model") else "not visible to prompt model"
+        lines.append(
+            f"- {tag or role_labels.get(role, role)}: {role}; {scope}; {availability}; {visible}"
+        )
+    return "\n".join(lines) or "- None"
+
+
+def _analysis_media_lines(assembled: dict[str, Any]) -> str:
+    manifest = {
+        str(asset.get("id")): asset
+        for asset in assembled.get("input", {}).get("media_manifest", {}).get("assets", [])
+        if asset.get("id")
+    }
+    lines = []
+    for item in assembled.get("media_inputs", []):
+        asset = manifest.get(str(item.get("asset_id")), {})
+        filename = asset.get("filename") or item.get("asset_id") or "media"
+        lines.append(f"- {item.get('reference')}: {filename} ({item.get('type')})")
+    return "\n".join(lines) or "- None"
+
+
+def _plan_context(plan: dict[str, Any], index: int, previous_prompt: str | None) -> str:
+    chunk = plan["chunks"][index - 1]
+    previous = plan["chunks"][index - 2] if index > 1 else None
+    following = plan["chunks"][index] if index < len(plan["chunks"]) else None
+    subjects = plan["global"].get("subject_anchors", [])
+    subject_text = "\n".join(
+        f"- {item['id']}: {item['meaning']}" for item in subjects
+    ) or "- None"
+    parts = [
+        "Sequence-wide Continuum preamble that will be prepended automatically:",
+        plan["global"]["sequence_preamble"] or "(none)",
+        "Internal sequence continuity anchors:",
+        plan["global"]["continuity_anchors"],
+        "Internal persistent constraints:",
+        plan["global"]["persistent_constraints"],
+        "Stable subject identities:",
+        subject_text,
+        "Chunk-local semantic plan:",
+        (
+            f"Start state: {chunk['start_state']}\n"
+            f"Action/progression: {chunk['action']}\n"
+            f"End state: {chunk['end_state']}\n"
+            f"Continuity: {chunk['continuity']}"
+            + (f"\nIntentional transition: {chunk['transition']}" if chunk["transition"] else "")
+        ),
+    ]
+    if previous is not None:
+        parts.append(f"Previous planned terminal state: {previous['end_state']}")
+    if previous_prompt:
+        parts.append(
+            "Previous chunk-local Continuum prompt. Carry forward its supported terminal state and stable identities; "
+            "do not reset to the sequence opening:\n" + previous_prompt
+        )
+    if following is not None:
+        parts.append(f"Following planned start state: {following['start_state']}")
+    return "\n\n".join(parts)
+
+
+def _configure_continuum_chunk_messages(
+    assembled: dict[str, Any],
+    body: dict[str, Any],
+    plan: dict[str, Any],
+    index: int,
+    *,
+    previous_prompt: str | None,
+    current_prompt: str | None = None,
+    instruction: str | None = None,
+    following_prompt: str | None = None,
+) -> dict[str, Any]:
+    settings = validate_continuum_settings(body)
+    allowed_references = chunk_reference_tags(
+        assembled["input"],
+        chunk_index=index,
+        chunks=settings["chunks"],
+    )
+    original_system = assembled.get("system_prompt") or {}
+    custom_guidance = (
+        str(original_system.get("content") or "").strip()
+        if original_system.get("custom")
+        else ""
+    )
+    start = (index - 1) * settings["chunk_seconds"]
+    end = index * settings["chunk_seconds"]
+    user_parts = [
+        f"Underlying user-selected H3 task: {body['mode']}",
+        (
+            f"Logical Continuum span: Chunk {index}/{settings['chunks']}, "
+            f"{format_timeline_seconds(start)}-{format_timeline_seconds(end)} seconds. "
+            "Do not output this Timeline header."
+        ),
+        (
+            "Authoritative downstream conditioning topology for this span:\n"
+            + _reference_scope_lines(
+                assembled["input"],
+                chunk_index=index,
+                chunks=settings["chunks"],
+            )
+        ),
+        (
+            "Public reference tags available to this chunk: "
+            + (", ".join(sorted(allowed_references)) if allowed_references else "None")
+        ),
+        "Prompt-model analysis media attached to this request:\n" + _analysis_media_lines(assembled),
+        f"Creative brief:\n{assembled['input']['creative_brief']}",
+        _plan_context(plan, index, previous_prompt),
+    ]
+    if current_prompt is not None:
+        user_parts.append(f"Current selected chunk body:\n{current_prompt}")
+    if instruction is not None:
+        user_parts.append(f"Chunk-local refinement instruction:\n{instruction}")
+    if following_prompt is not None:
+        user_parts.append(
+            "Following unchanged chunk-local prompt for boundary compatibility:\n" + following_prompt
+        )
+    if custom_guidance:
+        user_parts.append(
+            "User-supplied authoring guidance. Apply it only where compatible with the Continuum chunk contract:\n"
+            + custom_guidance
+        )
+    user_parts.append(
+        "Return only the complete replacement body for this logical span. Do not repeat the shared preamble. "
+        "Do not emit a standalone mode wrapper or any [start-end] / [Chunk N] header."
+    )
+
+    assembled["guide"] = {
+        "id": "h3-continuum-chunk-v2",
+        "title": "MiniMax H3 Continuum chunk authoring contract",
+    }
+    assembled["supporting_guides"] = []
+    assembled["system_prompt"] = {"custom": False, "content": CONTINUUM_CHUNK_SYSTEM_PROMPT}
+    assembled["messages"] = [
+        {
+            "role": "system",
+            "name": "h3_continuum_chunk_writer",
+            "content": CONTINUUM_CHUNK_SYSTEM_PROMPT,
+        },
+        {"role": "user", "content": "\n\n".join(user_parts)},
+    ]
+    assembled["input"].update(
+        {
+            "generation_target": GENERATION_TARGET_CONTINUUM,
+            "continuum_stage": "refine_chunk" if instruction is not None else "chunk",
+            "continuum": settings,
+            "continuum_chunk_index": index,
+            "continuum_chunk_allowed_references": sorted(allowed_references),
+            "continuum_plan": plan,
+        }
+    )
+    return assembled
+
+
+def assemble_continuum_chunk_request(
+    body: dict[str, Any],
+    plan: dict[str, Any],
+    index: int,
+    *,
+    previous_prompt: str | None,
+) -> dict[str, Any]:
+    settings = validate_continuum_settings(body)
+    if not 1 <= index <= settings["chunks"]:
+        raise ContinuumError("INVALID_CONTINUUM_CHUNK", "Chunk index is outside the configured sequence.")
+    single_body = dict(body)
+    single_body["duration_seconds"] = settings["chunk_seconds"]
+    single_body["generation_target"] = GENERATION_TARGET_CONTINUUM
+    assembled = assemble_request(single_body)
+    expected_references = stable_reference_tags(assembled["input"])
+    plan = validate_sequence_plan(
+        plan,
+        settings,
+        expected_references=expected_references,
+        persistent_references=persistent_reference_tags(
+            assembled["input"],
+            chunks=settings["chunks"],
+        ),
+        chunk_reference_scopes=sequence_reference_scopes(
+            assembled["input"],
+            chunks=settings["chunks"],
+        ),
+        allow_legacy=False,
+        allow_application_owned_fields=True,
+    )
+    return _configure_continuum_chunk_messages(
+        assembled,
+        body,
+        plan,
+        index,
+        previous_prompt=previous_prompt,
+    )
+
+
+def _contains_reserved_sequence_header(value: str) -> bool:
+    return any(
+        _LEGACY_CHUNK_HEADER.fullmatch(line) or _TIMELINE_HEADER.fullmatch(line)
+        for line in value.splitlines()
+    )
+
+
+def validate_generated_chunk(prompt: str, assembled: dict[str, Any]) -> str:
+    if not isinstance(prompt, str) or not prompt.strip():
+        raise ContinuumError("EMPTY_CONTINUUM_CHUNK", "The model returned an empty Continuum chunk prompt.")
+    value = prompt.strip()
+    request_input = assembled["input"]
+    preamble = str(
+        request_input.get("continuum_plan", {})
+        .get("global", {})
+        .get("sequence_preamble", "")
+    )
+    format_violations = continuum_chunk_format_violations(
+        value,
+        preamble=preamble,
+    )
+    if format_violations:
+        raise ContinuumError(
+            "INVALID_CONTINUUM_CHUNK_FORMAT",
+            "A generated Continuum chunk violated the chunk-local Timeline body contract.",
+            {
+                "chunk_index": request_input.get("continuum_chunk_index"),
+                "violations": format_violations,
+            },
+        )
+    if "continuum_chunk_allowed_references" in request_input:
+        allowed = set(request_input["continuum_chunk_allowed_references"])
+    else:
+        allowed = effective_reference_tags(request_input, continuum=True)
+    actual = reference_tags(value)
+    unexpected = actual - allowed
+    if unexpected:
+        raise ContinuumError(
+            "CONTINUUM_REFERENCE_IDENTITY_DRIFT",
+            "A generated chunk introduced reference labels outside the declared downstream sequence inventory.",
+            {"unexpected": sorted(unexpected), "allowed": sorted(allowed)},
+        )
+    planned_subjects = {
+        item["id"] for item in assembled["input"].get("continuum_plan", {}).get("global", {}).get("subject_anchors", [])
+    }
+    actual_subjects = subject_tags(value)
+    unexpected_subjects = actual_subjects - planned_subjects
+    if unexpected_subjects:
+        raise ContinuumError(
+            "CONTINUUM_SUBJECT_IDENTITY_DRIFT",
+            "A generated chunk introduced a subject label outside the stable sequence plan.",
+            {"unexpected": sorted(unexpected_subjects), "planned": sorted(planned_subjects)},
+        )
+    return value
+
+
+def _decimal_number(value: int | float | Decimal, *, positive: bool) -> Decimal:
+    try:
+        result = Decimal(str(value))
+    except (InvalidOperation, ValueError) as error:
+        raise ContinuumError("INVALID_CONTINUUM_DURATION", "Continuum timeline duration is invalid.") from error
+    if not result.is_finite() or (result <= 0 if positive else result < 0):
+        qualifier = "positive" if positive else "non-negative"
+        raise ContinuumError("INVALID_CONTINUUM_DURATION", f"Continuum timeline duration must be {qualifier}.")
+    return result
+
+
+def _decimal_seconds(value: int | float | Decimal) -> Decimal:
+    return _decimal_number(value, positive=True)
+
+
+def format_timeline_seconds(value: int | float | Decimal) -> str:
+    decimal_value = _decimal_number(value, positive=False)
+    rendered = format(decimal_value.normalize(), "f")
+    if "." in rendered:
+        rendered = rendered.rstrip("0").rstrip(".")
+    return rendered or "0"
+
+
+def _normalize_chunk_bodies(prompts: list[str]) -> list[str]:
+    if not isinstance(prompts, list) or not prompts:
+        raise ContinuumError("INVALID_CONTINUUM_SEQUENCE", "A Continuum sequence must contain at least one chunk prompt.")
+    normalized = []
+    for index, prompt in enumerate(prompts, start=1):
+        if not isinstance(prompt, str) or not prompt.strip():
+            raise ContinuumError(
+                "INVALID_CONTINUUM_SEQUENCE",
+                f"Chunk {index} prompt must be non-empty text.",
+                {"chunk_index": index},
+            )
+        value = prompt.strip()
+        if _contains_reserved_sequence_header(value):
+            raise ContinuumError(
+                "INVALID_CONTINUUM_CHUNK_FORMAT",
+                f"Chunk {index} contains a reserved Continuum timeline or legacy chunk header.",
+            )
+        normalized.append(value)
+    return normalized
+
+
+def serialize_timeline(preamble: str, prompts: list[str], chunk_seconds: int | float) -> str:
+    if not isinstance(preamble, str):
+        raise ContinuumError("INVALID_CONTINUUM_SEQUENCE", "Continuum shared preamble must be text.")
+    preamble_value = preamble.strip()
+    if preamble_value and _contains_reserved_sequence_header(preamble_value):
+        raise ContinuumError(
+            "INVALID_CONTINUUM_SEQUENCE",
+            "Continuum shared preamble cannot contain timeline or legacy chunk headers.",
+        )
+    bodies = _normalize_chunk_bodies(prompts)
+    duration = _decimal_seconds(chunk_seconds)
+    sections = []
+    for index, body in enumerate(bodies):
+        start = duration * index
+        end = duration * (index + 1)
+        sections.append(
+            f"[{format_timeline_seconds(start)}-{format_timeline_seconds(end)}s]\n{body}"
+        )
+    if preamble_value:
+        return preamble_value + "\n\n" + "\n\n".join(sections)
+    return "\n\n".join(sections)
+
+
+def parse_timeline_sequence(
+    script: str,
+    *,
+    expected_chunks: int,
+    chunk_seconds: int | float,
+) -> tuple[str, list[str]]:
+    if not isinstance(script, str) or not script.strip():
+        raise ContinuumError("INVALID_CONTINUUM_SEQUENCE", "Continuum sequence text is empty.")
+    duration = _decimal_seconds(chunk_seconds)
+    preamble_lines: list[str] = []
+    bodies: list[str] = []
+    body_lines: list[str] = []
+    current_index: int | None = None
+
+    def finish_body() -> None:
+        nonlocal body_lines
+        if current_index is None:
+            return
+        body = "\n".join(body_lines).strip()
+        if not body:
+            raise ContinuumError(
+                "INVALID_CONTINUUM_SEQUENCE",
+                f"Timeline section {current_index + 1} is empty.",
+                {"chunk_index": current_index + 1},
+            )
+        bodies.append(body)
+        body_lines = []
+
+    for line_number, line in enumerate(script.splitlines(), start=1):
+        match = _TIMELINE_HEADER.fullmatch(line)
+        if match:
+            finish_body()
+            next_index = 0 if current_index is None else current_index + 1
+            if next_index >= expected_chunks:
+                raise ContinuumError(
+                    "INVALID_CONTINUUM_SEQUENCE",
+                    "Timeline contains more sections than configured chunks.",
+                    {"line": line_number},
+                )
+            expected_start = duration * next_index
+            expected_end = duration * (next_index + 1)
+            actual_start = Decimal(match.group(1))
+            actual_end = Decimal(match.group(2))
+            if actual_start != expected_start or actual_end != expected_end:
+                raise ContinuumError(
+                    "INVALID_CONTINUUM_SEQUENCE",
+                    "Timeline boundaries must exactly follow the configured chunk_seconds.",
+                    {
+                        "line": line_number,
+                        "expected": f"[{format_timeline_seconds(expected_start)}-{format_timeline_seconds(expected_end)}s]",
+                        "actual": line.strip(),
+                    },
+                )
+            current_index = next_index
+            continue
+        if current_index is None:
+            if _LEGACY_CHUNK_HEADER.fullmatch(line):
+                raise ContinuumError(
+                    "INVALID_CONTINUUM_SEQUENCE",
+                    "Legacy [Chunk N] syntax is not canonical Continuum Timeline syntax.",
+                    {"line": line_number},
+                )
+            preamble_lines.append(line)
+        else:
+            if _LEGACY_CHUNK_HEADER.fullmatch(line):
+                raise ContinuumError(
+                    "INVALID_CONTINUUM_SEQUENCE",
+                    "Legacy [Chunk N] syntax cannot appear inside a Timeline sequence.",
+                    {"line": line_number},
+                )
+            body_lines.append(line)
+    finish_body()
+    if current_index is None:
+        raise ContinuumError("INVALID_CONTINUUM_SEQUENCE", "No canonical [start-end] Timeline sections were found.")
+    if len(bodies) != expected_chunks:
+        raise ContinuumError(
+            "INVALID_CONTINUUM_SEQUENCE",
+            "Continuum Timeline section count does not match the configured chunk count.",
+            {"expected": expected_chunks, "actual": len(bodies)},
+        )
+    preamble = "\n".join(preamble_lines).strip()
+    canonical = serialize_timeline(preamble, bodies, chunk_seconds)
+    if canonical != script.strip():
+        raise ContinuumError(
+            "INVALID_CONTINUUM_SEQUENCE",
+            "Continuum Timeline contains non-canonical whitespace or header formatting.",
+        )
+    return preamble, bodies
+
+
+def parse_chunk_prompts(script: str, *, expected_chunks: int | None = None) -> list[str]:
+    """Strict migration reader for saved v1 Prompt Writer drafts only."""
+    if not isinstance(script, str) or not script.strip():
+        raise ContinuumError("INVALID_CONTINUUM_SEQUENCE", "Continuum sequence text is empty.")
+    prompts: list[str] = []
+    current_index: int | None = None
+    body: list[str] = []
+
+    def finish() -> None:
+        nonlocal body
+        if current_index is None:
+            if any(line.strip() for line in body):
+                raise ContinuumError(
+                    "INVALID_CONTINUUM_SEQUENCE",
+                    "Legacy Continuum migration does not accept text before [Chunk 1].",
+                )
+            body = []
+            return
+        prompt = "\n".join(body).strip()
+        if not prompt:
+            raise ContinuumError(
+                "INVALID_CONTINUUM_SEQUENCE",
+                f"Legacy Chunk {current_index} prompt is empty.",
+                {"chunk_index": current_index},
+            )
+        prompts.append(prompt)
+        body = []
+
+    for line_number, line in enumerate(script.splitlines(), start=1):
+        match = _LEGACY_CHUNK_HEADER.fullmatch(line)
+        if match:
+            finish()
+            index = int(match.group(1))
+            expected_index = len(prompts) + 1
+            if index != expected_index:
+                raise ContinuumError(
+                    "INVALID_CONTINUUM_SEQUENCE",
+                    "Legacy Continuum chunk headers must be contiguous, unique, and one-based.",
+                    {"line": line_number, "expected": expected_index, "actual": index},
+                )
+            current_index = index
+            continue
+        if _TIMELINE_HEADER.fullmatch(line):
+            raise ContinuumError(
+                "INVALID_CONTINUUM_SEQUENCE",
+                "Legacy draft migration cannot mix [Chunk N] and Timeline headers.",
+                {"line": line_number},
+            )
+        body.append(line)
+    finish()
+    if not prompts:
+        raise ContinuumError("INVALID_CONTINUUM_SEQUENCE", "No legacy [Chunk N] sections were found.")
+    if expected_chunks is not None and len(prompts) != expected_chunks:
+        raise ContinuumError(
+            "INVALID_CONTINUUM_SEQUENCE",
+            "Legacy Continuum sequence chunk count does not match the configured count.",
+            {"expected": expected_chunks, "actual": len(prompts)},
+        )
+    return prompts
+
+
+def serialize_chunk_prompts(prompts: list[str]) -> str:
+    """Legacy v1 serializer retained only for deterministic saved-draft migration tests."""
+    bodies = _normalize_chunk_bodies(prompts)
+    return "\n\n".join(f"[Chunk {index}]\n{body}" for index, body in enumerate(bodies, start=1))
+
+
+def resolved_chunk_prompt(preamble: str, body: str) -> str:
+    preamble_value = str(preamble or "").strip()
+    body_value = str(body or "").strip()
+    if preamble_value:
+        return preamble_value + "\n\n" + body_value
+    return body_value
+
+
+def prompt_hash(prompt: str) -> str:
+    return hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+
+
+def sequence_result(
+    settings: dict[str, Any],
+    plan: dict[str, Any],
+    prompts: list[str],
+    *,
+    preamble: str | None = None,
+    downstream_reference_inventory: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    bodies = _normalize_chunk_bodies(prompts)
+    if len(bodies) != settings["chunks"]:
+        raise ContinuumError(
+            "INVALID_CONTINUUM_SEQUENCE",
+            "Continuum chunk count does not match configured settings.",
+            {"expected": settings["chunks"], "actual": len(bodies)},
+        )
+    shared = (
+        str(plan.get("global", {}).get("sequence_preamble", ""))
+        if preamble is None
+        else str(preamble)
+    ).strip()
+    canonical = serialize_timeline(shared, bodies, settings["chunk_seconds"])
+    parsed_preamble, parsed_bodies = parse_timeline_sequence(
+        canonical,
+        expected_chunks=settings["chunks"],
+        chunk_seconds=settings["chunk_seconds"],
+    )
+    if parsed_preamble != shared or parsed_bodies != bodies:
+        raise ContinuumError("INVALID_CONTINUUM_SEQUENCE", "Canonical Continuum Timeline did not round-trip.")
+    chunks = []
+    for index, body in enumerate(parsed_bodies, start=1):
+        resolved = resolved_chunk_prompt(parsed_preamble, body)
+        chunks.append({
+            "index": index,
+            "body": body,
+            "prompt": body,
+            "resolved_prompt": resolved,
+            "hash": prompt_hash(resolved),
+        })
+    result = {
+        "schema_version": CONTINUUM_SCHEMA_VERSION,
+        "settings": settings,
+        "plan": plan,
+        "preamble": parsed_preamble,
+        "chunks": chunks,
+        "prompt": canonical,
+    }
+    if downstream_reference_inventory is not None:
+        result["downstream_reference_inventory"] = normalized_downstream_inventory(
+            downstream_reference_inventory
+        )
+    return result
+
+
+def _parse_current_sequence(
+    text: str,
+    settings: dict[str, Any],
+    *,
+    allow_legacy: bool = False,
+) -> tuple[str, list[str], bool]:
+    try:
+        preamble, bodies = parse_timeline_sequence(
+            text,
+            expected_chunks=settings["chunks"],
+            chunk_seconds=settings["chunk_seconds"],
+        )
+        return preamble, bodies, False
+    except ContinuumError as timeline_error:
+        if not allow_legacy:
+            raise timeline_error
+        try:
+            bodies = parse_chunk_prompts(text, expected_chunks=settings["chunks"])
+        except ContinuumError:
+            raise timeline_error
+        return "", bodies, True
+
+
+def assemble_continuum_refinement(
+    body: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any], int, dict[str, Any]]:
+    settings = validate_continuum_settings(body)
+    continuum = body.get("continuum")
+    if not isinstance(continuum, dict):
+        raise ContinuumError("INVALID_CONTINUUM_SETTINGS", "H3 Continuum refinement settings are missing.")
+    plan_value = continuum.get("plan")
+    if not isinstance(plan_value, dict):
+        raise ContinuumError("INVALID_CONTINUUM_PLAN", "H3 Continuum refinement requires its saved sequence plan.")
+
+    plan_request = assemble_continuum_plan_request(body)
+    active_inventory = plan_request["input"]["downstream_reference_inventory"]
+    saved_inventory = validate_saved_downstream_inventory(
+        continuum.get("downstream_reference_inventory"),
+        active_inventory,
+    )
+    expected_references = stable_reference_tags(plan_request["input"])
+    plan = validate_sequence_plan(
+        plan_value,
+        settings,
+        expected_references=expected_references,
+        persistent_references=persistent_reference_tags(
+            plan_request["input"],
+            chunks=settings["chunks"],
+        ),
+        chunk_reference_scopes=sequence_reference_scopes(
+            plan_request["input"],
+            chunks=settings["chunks"],
+        ),
+        allow_legacy=True,
+        allow_application_owned_fields=plan_value.get("schema_version") == CONTINUUM_SCHEMA_VERSION,
+    )
+    current_text = str(body.get("current_prompt") or "")
+    preamble, prompts, migrated_legacy = _parse_current_sequence(
+        current_text,
+        settings,
+        allow_legacy=plan_value.get("schema_version") == LEGACY_CONTINUUM_SCHEMA_VERSION,
+    )
+    if not migrated_legacy and preamble != plan["global"]["sequence_preamble"]:
+        raise ContinuumError(
+            "INVALID_CONTINUUM_SEQUENCE",
+            "The edited Timeline preamble no longer matches the saved sequence-wide plan. Regenerate the sequence to change global state.",
+        )
+    _preflight_body_references(
+        plan_request["input"],
+        [
+            plan_request["input"]["creative_brief"],
+            current_text,
+            str(body.get("instruction") or ""),
+        ],
+    )
+    validate_sequence_reference_scope(
+        plan_request["input"],
+        preamble=preamble,
+        prompts=prompts,
+        chunks=settings["chunks"],
+    )
+    chunk_index = continuum.get("chunk_index")
+    if not isinstance(chunk_index, int) or isinstance(chunk_index, bool) or not 1 <= chunk_index <= settings["chunks"]:
+        raise ContinuumError(
+            "INVALID_CONTINUUM_CHUNK",
+            "Select a valid one-based Continuum chunk to refine.",
+            {"chunk_index": chunk_index},
+        )
+
+    refine_body = dict(body)
+    refine_body["duration_seconds"] = settings["chunk_seconds"]
+    refine_body["generation_target"] = GENERATION_TARGET_CONTINUUM
+    refine_body["current_prompt"] = prompts[chunk_index - 1]
+    assembled = assemble_refinement(refine_body, None)
+    previous_prompt = prompts[chunk_index - 2] if chunk_index > 1 else None
+    following_prompt = prompts[chunk_index] if chunk_index < len(prompts) else None
+    assembled = _configure_continuum_chunk_messages(
+        assembled,
+        body,
+        plan,
+        chunk_index,
+        previous_prompt=previous_prompt,
+        current_prompt=prompts[chunk_index - 1],
+        instruction=str(body.get("instruction") or ""),
+        following_prompt=following_prompt,
+    )
+    return assembled, {
+        "preamble": preamble,
+        "prompts": prompts,
+        "downstream_reference_inventory": saved_inventory,
+    }, chunk_index, plan
+
+
+def apply_continuum_refinement(
+    result_prompt: str,
+    assembled: dict[str, Any],
+    sequence_state: dict[str, Any],
+    chunk_index: int,
+    plan: dict[str, Any],
+) -> dict[str, Any]:
+    refined = validate_generated_chunk(result_prompt, assembled)
+    preamble = str(sequence_state.get("preamble") or "")
+    if preamble and refined.startswith(preamble):
+        raise ContinuumError(
+            "INVALID_CONTINUUM_CHUNK_FORMAT",
+            "Chunk-local refinement repeated the immutable sequence-wide preamble.",
+            {"chunk_index": chunk_index},
+        )
+    updated = list(sequence_state["prompts"])
+    updated[chunk_index - 1] = refined
+    settings = assembled["input"]["continuum"]
+    return sequence_result(
+        settings,
+        plan,
+        updated,
+        preamble=preamble,
+        downstream_reference_inventory=sequence_state.get("downstream_reference_inventory"),
+    )

--- a/backend/h3_pipeline.py
+++ b/backend/h3_pipeline.py
@@ -4,6 +4,7 @@ import base64
 import time
 from typing import Any, Callable
 
+from .continuum import continuum_chunk_format_violations
 from .context import (
     CHAT_TEMPLATE_OVERHEAD_TOKENS,
     CONTEXT_SAFETY_TOKENS,
@@ -15,6 +16,7 @@ from .models.contract import ModelError, final_message_text
 from .prompt_audit import audit_prompt, camera_structure_requested
 from .prompt_repair import (
     audit_failures,
+    continuum_chunk_repair_messages,
     dialogue_lines,
     explicit_constraint_violations,
     multimodal_repair_messages,
@@ -137,30 +139,97 @@ def _messages(
     }
 
 
+def _prompt_for_audit(prompt: str, assembled: dict[str, Any]) -> str:
+    request_input = assembled.get("input", {})
+    if (
+        request_input.get("generation_target") == "continuum"
+        and request_input.get("continuum_stage") in {"chunk", "refine_chunk"}
+    ):
+        preamble = str(
+            request_input.get("continuum_plan", {})
+            .get("global", {})
+            .get("sequence_preamble", "")
+        ).strip()
+        if preamble:
+            return preamble + "\n\n" + prompt.strip()
+    return prompt
+
+
+def _is_continuum_chunk_stage(assembled: dict[str, Any]) -> bool:
+    request_input = assembled.get("input", {})
+    return (
+        request_input.get("generation_target") == "continuum"
+        and request_input.get("continuum_stage") in {"chunk", "refine_chunk"}
+    )
+
+
 def _audit(
     prompt: str,
     assembled: dict[str, Any],
 ) -> tuple[dict[str, Any], ReferencePolicy, str, float | None, bool]:
-    duration_seconds = assembled["input"].get("duration_seconds")
+    request_input = assembled["input"]
+    duration_seconds = request_input.get("duration_seconds")
     intent_text = "\n".join(
-        str(assembled["input"].get(key, ""))
+        str(request_input.get(key, ""))
         for key in ("creative_brief", "current_prompt", "instruction")
-        if assembled["input"].get(key)
+        if request_input.get(key)
     )
     camera_structure_allowed = camera_structure_requested(intent_text)
+    audited_prompt = _prompt_for_audit(prompt, assembled)
+
+    if _is_continuum_chunk_stage(assembled):
+        allowed = set(request_input.get("continuum_chunk_allowed_references") or [])
+        actual_reference_tags = reference_tags(audited_prompt)
+        unexpected_reference_tags = sorted(actual_reference_tags - allowed)
+        constraint_violations = explicit_constraint_violations(intent_text, audited_prompt)
+        preamble = str(
+            request_input.get("continuum_plan", {})
+            .get("global", {})
+            .get("sequence_preamble", "")
+        )
+        format_violations = continuum_chunk_format_violations(
+            prompt,
+            preamble=preamble,
+        )
+        result = {
+            "mode": request_input.get("mode"),
+            "continuum_stage": request_input.get("continuum_stage"),
+            "official_format_pass": None,
+            "reference_understanding": "continuum_timeline_chunk",
+            "required_reference_tags": [],
+            "mutable_reference_tags": [],
+            "allowed_reference_tags": sorted(allowed),
+            "missing_reference_tags": [],
+            "unexpected_reference_tags": unexpected_reference_tags,
+            "explicit_constraint_violations": constraint_violations,
+            "format_violations": format_violations,
+            "repair_required": bool(
+                unexpected_reference_tags
+                or constraint_violations
+                or format_violations
+            ),
+        }
+        return (
+            result,
+            ReferencePolicy(set(), set(), allowed),
+            intent_text,
+            duration_seconds,
+            camera_structure_allowed,
+        )
+
     result = audit_prompt(
-        prompt,
-        assembled["input"]["mode"],
+        audited_prompt,
+        request_input["mode"],
         duration_seconds,
         camera_structure_allowed,
     )
-    policy = reference_policy(assembled["input"])
-    actual_reference_tags = reference_tags(prompt)
+    policy = reference_policy(request_input)
+    actual_reference_tags = reference_tags(audited_prompt)
     missing_reference_tags = sorted(policy.required - actual_reference_tags)
     unexpected_reference_tags = sorted(actual_reference_tags - policy.allowed)
     has_unexpected_audio_task = unexpected_audio_task(result.get("task_label"), actual_reference_tags)
-    constraint_violations = explicit_constraint_violations(intent_text, prompt)
-    if assembled["input"]["mode"] == "Reference":
+    constraint_violations = explicit_constraint_violations(intent_text, audited_prompt)
+    if request_input["mode"] == "Reference":
         result["missing_reference_tags"] = missing_reference_tags
         result["unexpected_reference_tags"] = unexpected_reference_tags
         result["required_reference_tags"] = sorted(policy.required)
@@ -179,19 +248,39 @@ def _audit(
 
 
 def validate_media_capabilities(model_info: dict[str, Any], assembled: dict[str, Any]) -> None:
-    mode = assembled.get("input", {}).get("mode")
+    request_input = assembled.get("input", {})
+    mode = request_input.get("mode")
+    visual_media_attached = any(
+        item.get("type") in {"image", "video"}
+        for item in assembled.get("media_inputs", [])
+    )
+    continuum_declared_only = (
+        request_input.get("generation_target") == "continuum"
+        and not visual_media_attached
+    )
+    direct_vision_required = (
+        visual_media_attached
+        or (mode != "T2VA" and not continuum_declared_only)
+    )
     if (
         model_info.get("family") == "gguf"
         and model_info.get("capabilities", {}).get("images") is False
-        and mode != "T2VA"
+        and direct_vision_required
     ):
+        display_mode = request_input.get("underlying_mode") or mode
         raise ModelError(
             "DIRECT_VISION_REQUIRED",
-            "This Direct GGUF model is running without a compatible vision projector. Only T2VA is available.",
+            "This request needs visual analysis, but the selected Direct GGUF model has no compatible vision projector.",
             {
-                "mode": mode,
-                "supported_modes": ["T2VA"],
-                "suggestion": "Switch to T2VA or add the matching mmproj GGUF beside the model.",
+                "mode": display_mode,
+                "supported_without_vision": [
+                    "T2VA",
+                    "H3 Continuum modes using only workflow-declared conditioning",
+                ],
+                "suggestion": (
+                    "Add the matching mmproj GGUF, or for H3 Continuum remove Prompt Writer image/video "
+                    "analysis media and rely on the declared H3 Continuum workflow conditioning."
+                ),
             },
         )
     required = {item["requires_capability"] for item in assembled["media_inputs"]}
@@ -315,14 +404,20 @@ def run_h3_pipeline(
     expected_reference_tags = reference_policy_value.required
     allowed_reference_tags = reference_policy_value.allowed
     initial_reference_tags = reference_tags(prompt)
-    repair_reference_tags = (initial_reference_tags & allowed_reference_tags) | expected_reference_tags
+    repair_reference_tags = (
+        (initial_reference_tags & allowed_reference_tags)
+        | set(initial_audit.get("missing_reference_tags", []))
+    )
     format_repair_attempted = False
     format_repair_applied = False
     format_repair_tokens = 0
     format_repair_reason = None
     format_repair_failure = None
     format_repair_method = None
-    repair_needed = assembled["input"]["mode"] == "Reference" and initial_audit.get("repair_required") is True
+    continuum_chunk_stage = _is_continuum_chunk_stage(assembled)
+    repair_needed = initial_audit.get("repair_required") is True and (
+        continuum_chunk_stage or assembled["input"]["mode"] == "Reference"
+    )
     if repair_needed:
         format_repair_attempted = True
         failed_checks = audit_failures(initial_audit)
@@ -331,7 +426,16 @@ def run_h3_pipeline(
         has_prepared_visual_media = any(
             item.get("type") in {"image", "video"} for item in assembled.get("media_inputs", [])
         )
-        if missing_active_references and has_prepared_visual_media:
+        if continuum_chunk_stage:
+            format_repair_method = "continuum narrow text correction"
+            repair_messages = continuum_chunk_repair_messages(
+                assembled,
+                prompt,
+                failed_checks,
+                repair_reference_tags,
+                allowed_reference_tags,
+            )
+        elif missing_active_references and has_prepared_visual_media:
             format_repair_method = "multimodal reference correction"
             repair_messages = multimodal_repair_messages(
                 messages,
@@ -376,30 +480,38 @@ def run_h3_pipeline(
             thinking=False,
             qwen_reasoning_contract=qwen_reasoning_contract,
         )
-        repaired_audit = audit_prompt(
-            repaired,
-            assembled["input"]["mode"],
-            duration_seconds,
-            camera_structure_allowed,
-        )
-        repaired_tags = reference_tags(repaired)
-        repaired_audit["missing_reference_tags"] = sorted(expected_reference_tags - repaired_tags)
-        repaired_audit["unexpected_reference_tags"] = sorted(repaired_tags - allowed_reference_tags)
-        repaired_audit["required_reference_tags"] = sorted(reference_policy_value.required)
-        repaired_audit["mutable_reference_tags"] = sorted(reference_policy_value.mutable)
-        repaired_audit["allowed_reference_tags"] = sorted(reference_policy_value.allowed)
-        repaired_audit["unexpected_audio_task"] = unexpected_audio_task(
-            repaired_audit.get("task_label"), repaired_tags
-        )
-        repaired_audit["explicit_constraint_violations"] = explicit_constraint_violations(intent_text, repaired)
-        repaired_audit["repair_required"] = bool(
-            repaired_audit.get("repair_required")
-            or repaired_audit["missing_reference_tags"]
-            or repaired_audit["unexpected_reference_tags"]
-            or repaired_audit["unexpected_audio_task"]
-            or repaired_audit["explicit_constraint_violations"]
-        )
-        repair_tags_match = repaired_tags == repair_reference_tags
+        repaired_audit_prompt = _prompt_for_audit(repaired, assembled)
+        repaired_raw_tags = reference_tags(repaired)
+        if continuum_chunk_stage:
+            repaired_audit, _, _, _, _ = _audit(repaired, assembled)
+        else:
+            repaired_audit = audit_prompt(
+                repaired_audit_prompt,
+                assembled["input"]["mode"],
+                duration_seconds,
+                camera_structure_allowed,
+            )
+            repaired_tags = reference_tags(repaired_audit_prompt)
+            repaired_audit["missing_reference_tags"] = sorted(expected_reference_tags - repaired_tags)
+            repaired_audit["unexpected_reference_tags"] = sorted(repaired_tags - allowed_reference_tags)
+            repaired_audit["required_reference_tags"] = sorted(reference_policy_value.required)
+            repaired_audit["mutable_reference_tags"] = sorted(reference_policy_value.mutable)
+            repaired_audit["allowed_reference_tags"] = sorted(reference_policy_value.allowed)
+            repaired_audit["unexpected_audio_task"] = unexpected_audio_task(
+                repaired_audit.get("task_label"), repaired_tags
+            )
+            repaired_audit["explicit_constraint_violations"] = explicit_constraint_violations(
+                intent_text,
+                repaired_audit_prompt,
+            )
+            repaired_audit["repair_required"] = bool(
+                repaired_audit.get("repair_required")
+                or repaired_audit["missing_reference_tags"]
+                or repaired_audit["unexpected_reference_tags"]
+                or repaired_audit["unexpected_audio_task"]
+                or repaired_audit["explicit_constraint_violations"]
+            )
+        repair_tags_match = repaired_raw_tags == repair_reference_tags
         dialogue_preserved = dialogue_lines(repaired) == dialogue_lines(prompt)
         if (
             repaired

--- a/backend/media.py
+++ b/backend/media.py
@@ -86,6 +86,201 @@ class MediaError(Exception):
         self.message = message
 
 
+WORKFLOW_SCALE_X_NODE_CLASS = "ImageScaleToTotalPixelsX"
+WORKFLOW_SCALE_X_CONTRACT_SHA = "79e831097bb7a76ade3a28359300e62332086c42"
+WORKFLOW_SCALE_X_PLAN_VERSION = 1
+WORKFLOW_SCALE_X_RESIZE_MODES = {"stretch", "crop", "pad"}
+# Only Lanczos is admitted for exact pre-execution materialization today. The
+# reviewed node delegates this method to comfy.utils.lanczos, which is itself a
+# Pillow RGB uint8 Lanczos resize; reproducing it here does not require a GPU or
+# an unpinned torch interpolation implementation.
+WORKFLOW_SCALE_X_UPSCALE_METHODS = {"lanczos"}
+
+
+def normalize_workflow_materialization_plan(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise MediaError("INVALID_WORKFLOW_MATERIALIZATION", "Workflow image materialization plan must be an object.")
+    required = {
+        "kind",
+        "version",
+        "node_class",
+        "contract_sha",
+        "megapixels",
+        "multiple_of",
+        "resize_mode",
+        "upscale_method",
+    }
+    if set(value) != required:
+        raise MediaError(
+            "INVALID_WORKFLOW_MATERIALIZATION",
+            "Workflow image materialization plan has an unsupported schema.",
+        )
+    if value.get("kind") != "image_scale_to_total_pixels_x":
+        raise MediaError("INVALID_WORKFLOW_MATERIALIZATION", "Workflow image materialization kind is unsupported.")
+    if value.get("version") != WORKFLOW_SCALE_X_PLAN_VERSION:
+        raise MediaError("INVALID_WORKFLOW_MATERIALIZATION", "Workflow image materialization version is unsupported.")
+    if value.get("node_class") != WORKFLOW_SCALE_X_NODE_CLASS:
+        raise MediaError("INVALID_WORKFLOW_MATERIALIZATION", "Workflow image materialization node class is unsupported.")
+    if value.get("contract_sha") != WORKFLOW_SCALE_X_CONTRACT_SHA:
+        raise MediaError(
+            "WORKFLOW_MATERIALIZATION_CONTRACT_DRIFT",
+            "The Scale Image to Total Pixels Adv contract differs from the reviewed implementation.",
+        )
+
+    megapixels_raw = value.get("megapixels")
+    if isinstance(megapixels_raw, bool):
+        raise MediaError("INVALID_WORKFLOW_MATERIALIZATION", "Megapixels must be a finite number.")
+    try:
+        megapixels = float(megapixels_raw)
+    except (TypeError, ValueError, OverflowError) as error:
+        raise MediaError("INVALID_WORKFLOW_MATERIALIZATION", "Megapixels must be a finite number.") from error
+    if not math.isfinite(megapixels) or megapixels < 0.0 or megapixels > 16.0:
+        raise MediaError("INVALID_WORKFLOW_MATERIALIZATION", "Megapixels must be between 0 and 16.")
+
+    multiple_of = value.get("multiple_of")
+    if isinstance(multiple_of, bool) or not isinstance(multiple_of, int) or not 1 <= multiple_of <= 128:
+        raise MediaError("INVALID_WORKFLOW_MATERIALIZATION", "multiple_of must be an integer between 1 and 128.")
+
+    resize_mode = str(value.get("resize_mode", "")).strip().lower()
+    if resize_mode not in WORKFLOW_SCALE_X_RESIZE_MODES:
+        raise MediaError("INVALID_WORKFLOW_MATERIALIZATION", "Resize mode is unsupported.")
+
+    upscale_method = str(value.get("upscale_method", "")).strip().lower()
+    if upscale_method not in WORKFLOW_SCALE_X_UPSCALE_METHODS:
+        raise MediaError(
+            "WORKFLOW_MATERIALIZATION_UNSUPPORTED",
+            "Only Lanczos Scale Image to Total Pixels Adv chains can currently be materialized exactly.",
+        )
+    return {
+        "kind": "image_scale_to_total_pixels_x",
+        "version": WORKFLOW_SCALE_X_PLAN_VERSION,
+        "node_class": WORKFLOW_SCALE_X_NODE_CLASS,
+        "contract_sha": WORKFLOW_SCALE_X_CONTRACT_SHA,
+        "megapixels": megapixels,
+        "multiple_of": multiple_of,
+        "resize_mode": resize_mode,
+        "upscale_method": upscale_method,
+    }
+
+
+def _scale_x_geometry(width: int, height: int, plan: dict[str, Any]) -> dict[str, int]:
+    megapixels = float(plan["megapixels"])
+    multiple_of = int(plan["multiple_of"])
+    resize_mode = str(plan["resize_mode"])
+
+    if megapixels == 0:
+        target_width = width
+        target_height = height
+    else:
+        total = int(megapixels * 1_000_000)
+        scale_by = math.sqrt(total / (width * height))
+        target_width = round(width * scale_by)
+        target_height = round(height * scale_by)
+
+    if multiple_of > 1:
+        target_width = target_width - (target_width % multiple_of)
+        target_height = target_height - (target_height % multiple_of)
+
+    target_width = max(multiple_of, target_width)
+    target_height = max(multiple_of, target_height)
+    resize_width = target_width
+    resize_height = target_height
+    x = y = x2 = y2 = 0
+    pad_left = pad_right = pad_top = pad_bottom = 0
+
+    if resize_mode == "pad":
+        ratio = min(target_width / width, target_height / height)
+        new_width = round(width * ratio)
+        new_height = round(height * ratio)
+        pad_left = (target_width - new_width) // 2
+        pad_right = target_width - new_width - pad_left
+        pad_top = (target_height - new_height) // 2
+        pad_bottom = target_height - new_height - pad_top
+        resize_width = new_width
+        resize_height = new_height
+    elif resize_mode == "crop":
+        ratio = max(target_width / width, target_height / height)
+        new_width = round(width * ratio)
+        new_height = round(height * ratio)
+        x = (new_width - target_width) // 2
+        y = (new_height - target_height) // 2
+        x2 = x + target_width
+        y2 = y + target_height
+        if x2 > new_width:
+            x -= x2 - new_width
+        if x < 0:
+            x = 0
+        if y2 > new_height:
+            y -= y2 - new_height
+        if y < 0:
+            y = 0
+        resize_width = new_width
+        resize_height = new_height
+
+    return {
+        "target_width": target_width,
+        "target_height": target_height,
+        "resize_width": resize_width,
+        "resize_height": resize_height,
+        "x": x,
+        "y": y,
+        "x2": x2,
+        "y2": y2,
+        "pad_left": pad_left,
+        "pad_right": pad_right,
+        "pad_top": pad_top,
+        "pad_bottom": pad_bottom,
+    }
+
+
+def materialize_workflow_image(source: Path, target: Path, raw_plan: Any) -> dict[str, Any]:
+    plan = normalize_workflow_materialization_plan(raw_plan)
+    with Image.open(source) as opened:
+        if int(getattr(opened, "n_frames", 1) or 1) != 1:
+            raise MediaError(
+                "WORKFLOW_MATERIALIZATION_UNSUPPORTED",
+                "Animated workflow image sources cannot be materialized as one exact H3 reference image.",
+            )
+        image = ImageOps.exif_transpose(opened).convert("RGB")
+
+    geometry = _scale_x_geometry(image.width, image.height, plan)
+    # BigStationW's reviewed Lanczos branch calls comfy.utils.lanczos. ComfyUI's
+    # implementation converts the RGB tensor back to uint8 and calls Pillow
+    # Image.Resampling.LANCZOS, so this operation is pixel-equivalent for a
+    # static LoadImage/Image Conveyor source.
+    output = image.resize(
+        (geometry["resize_width"], geometry["resize_height"]),
+        Image.Resampling.LANCZOS,
+    )
+
+    if plan["resize_mode"] == "pad":
+        if any(geometry[name] > 0 for name in ("pad_left", "pad_right", "pad_top", "pad_bottom")):
+            padded = Image.new("RGB", (geometry["target_width"], geometry["target_height"]), (0, 0, 0))
+            padded.paste(output, (geometry["pad_left"], geometry["pad_top"]))
+            output = padded
+    elif plan["resize_mode"] == "crop":
+        if any(geometry[name] > 0 for name in ("x", "y", "x2", "y2")):
+            output = output.crop((geometry["x"], geometry["y"], geometry["x2"], geometry["y2"]))
+
+    multiple_of = int(plan["multiple_of"])
+    if multiple_of > 1 and (output.width % multiple_of != 0 or output.height % multiple_of != 0):
+        final_width = output.width
+        final_height = output.height
+        x = (final_width % multiple_of) // 2
+        y = (final_height % multiple_of) // 2
+        x2 = final_width - ((final_width % multiple_of) - x)
+        y2 = final_height - ((final_height % multiple_of) - y)
+        output = output.crop((x, y, x2, y2))
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    output.save(target, "PNG")
+    return {
+        "width": output.width,
+        "height": output.height,
+        "plan": plan,
+    }
+
+
 class MediaStore:
     def __init__(self) -> None:
         self.sessions: dict[str, list[dict[str, Any]]] = {}

--- a/backend/models/api_provider_backend.py
+++ b/backend/models/api_provider_backend.py
@@ -493,7 +493,8 @@ class ApiProviderBackend:
         }
 
     def _local_custom_model_metadata(self, connection: ApiConnection) -> dict[str, dict[str, Any]]:
-        if connection.preset != "custom" or not _is_loopback(urlsplit(connection.base_url).hostname or ""):
+        hostname = urlsplit(connection.base_url).hostname or ""
+        if connection.preset != "custom" or not (_is_loopback(hostname) or _is_private_lan(hostname)):
             return {}
         try:
             data, _headers = self._request_json(connection, "GET", "/api/v1/models")

--- a/backend/prompt_repair.py
+++ b/backend/prompt_repair.py
@@ -74,6 +74,7 @@ def audit_failures(audit: dict[str, Any]) -> list[str]:
         failures.append("unexpected reference tags: " + ", ".join(audit["unexpected_reference_tags"]))
     if audit.get("unexpected_audio_task"):
         failures.append("audio reference/reuse declared without a canonically requested uploaded audio reference")
+    failures.extend(audit.get("format_violations") or [])
     failures.extend(audit.get("explicit_constraint_violations") or [])
     return failures
 
@@ -106,6 +107,44 @@ def narrow_repair_messages(
         {
             "role": "user",
             "content": f"ORIGINAL REQUEST:\n{original_request}\n\nDRAFT TO CORRECT:\n{draft}",
+        },
+    ]
+
+
+def continuum_chunk_repair_messages(
+    assembled: dict[str, Any],
+    draft: str,
+    violations: list[str],
+    expected_tags: set[str],
+    allowed_tags: set[str],
+) -> list[dict[str, str]]:
+    original_request = next(
+        message["content"]
+        for message in assembled["messages"]
+        if message["role"] == "user"
+    )
+    required = ", ".join(sorted(expected_tags)) or "none"
+    allowed = ", ".join(sorted(allowed_tags)) or "none"
+    return [
+        {
+            "role": "system",
+            "content": (
+                "This is a narrow correction of one MiniMax H3 Continuum Timeline chunk body. "
+                "Correct only the objective failures listed below and preserve every other supported action, state, "
+                "camera choice, dialogue line, sound cue, and creative choice unchanged. Return only the corrected "
+                "chunk body. Do not add a shared preamble, Timeline header, standalone I2VA/FL2VA/L2VA alignment line, "
+                "Reference-mode section wrapper, JSON, Markdown, or commentary. The exact public reference tags that "
+                f"must remain in this chunk body are: {required}. The exact public reference tags permitted in this "
+                f"chunk are: {allowed}. Do not add any other numbered media tag. Violations: "
+                + "; ".join(violations)
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                f"ORIGINAL CONTINUUM CHUNK REQUEST:\n{original_request}\n\n"
+                f"DRAFT CHUNK BODY TO CORRECT:\n{draft}"
+            ),
         },
     ]
 

--- a/backend/references.py
+++ b/backend/references.py
@@ -8,6 +8,17 @@ from typing import Any
 CANONICAL_REFERENCE_TAG = re.compile(r"<(Picture|Video|Audio) ([1-9]\d*)>")
 REFERENCE_TAG = re.compile(r"<\s*(Picture|Video|Audio)\s+(\d+)\s*>", re.IGNORECASE)
 
+DOWNSTREAM_REFERENCE_SCHEMA_VERSION = 1
+DOWNSTREAM_REFERENCE_ROLES = {
+    "reference_image": "image",
+    "first_frame": "image",
+    "last_frame": "image",
+    "video_reference": "video",
+    "reference_audio": "audio",
+    "driving_audio": "audio",
+}
+DOWNSTREAM_REFERENCE_SOURCES = {"workflow", "manual"}
+
 
 def canonical_reference_tags(text: str, kind: str | None = None) -> set[str]:
     return {
@@ -21,7 +32,194 @@ def reference_tags(text: str) -> set[str]:
     return {
         f"<{kind.title()} {number}>"
         for kind, number in REFERENCE_TAG.findall(text)
+        if int(number) > 0
     }
+
+
+def normalize_downstream_reference_inventory(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {"schema_version": DOWNSTREAM_REFERENCE_SCHEMA_VERSION, "items": []}
+    if not isinstance(value, dict):
+        raise ValueError("Downstream H3 reference inventory must be a JSON object.")
+    schema_version = value.get("schema_version", DOWNSTREAM_REFERENCE_SCHEMA_VERSION)
+    if schema_version != DOWNSTREAM_REFERENCE_SCHEMA_VERSION:
+        raise ValueError(
+            f"Unsupported downstream H3 reference inventory schema {schema_version}; "
+            f"expected {DOWNSTREAM_REFERENCE_SCHEMA_VERSION}."
+        )
+    raw_items = value.get("items", [])
+    if not isinstance(raw_items, list):
+        raise ValueError("Downstream H3 reference inventory items must be a list.")
+
+    items: list[dict[str, Any]] = []
+    seen_tags: set[str] = set()
+    seen_singleton_roles: set[str] = set()
+    for offset, raw in enumerate(raw_items, start=1):
+        if not isinstance(raw, dict):
+            raise ValueError(f"Downstream H3 reference inventory item {offset} must be an object.")
+        role = raw.get("role")
+        if role not in DOWNSTREAM_REFERENCE_ROLES:
+            raise ValueError(f"Downstream H3 reference inventory item {offset} has an unsupported role.")
+        if role != "reference_image":
+            if role in seen_singleton_roles:
+                raise ValueError(f"Downstream H3 reference inventory defines role {role!r} more than once.")
+            seen_singleton_roles.add(role)
+
+        expected_kind = DOWNSTREAM_REFERENCE_ROLES[role]
+        kind = raw.get("kind", expected_kind)
+        if kind != expected_kind:
+            raise ValueError(
+                f"Downstream H3 reference inventory item {offset} kind must be {expected_kind!r} for role {role!r}."
+            )
+        source = raw.get("source", "workflow")
+        if source not in DOWNSTREAM_REFERENCE_SOURCES:
+            raise ValueError(f"Downstream H3 reference inventory item {offset} has an unsupported source.")
+        visible_to_model = raw.get("visible_to_model", False)
+        if not isinstance(visible_to_model, bool):
+            raise ValueError(
+                f"Downstream H3 reference inventory item {offset} visible_to_model must be a boolean."
+            )
+
+        tag = raw.get("tag")
+        if tag in (None, ""):
+            tag = None
+        else:
+            tag = str(tag)
+            if reference_tags(tag) != {tag} or not CANONICAL_REFERENCE_TAG.fullmatch(tag):
+                raise ValueError(
+                    f"Downstream H3 reference inventory item {offset} uses an invalid public reference tag."
+                )
+            if tag in seen_tags:
+                raise ValueError(f"Downstream H3 reference inventory defines {tag} more than once.")
+            seen_tags.add(tag)
+
+        if role == "reference_image" and (tag is None or not tag.startswith("<Picture ")):
+            raise ValueError(
+                f"Downstream H3 reference inventory item {offset} must use a canonical <Picture N> tag."
+            )
+        if role in {"first_frame", "last_frame"} and tag is not None and not tag.startswith("<Picture "):
+            raise ValueError(f"Downstream H3 role {role!r} can only own a <Picture N> tag.")
+        if role == "video_reference" and tag != "<Video 1>":
+            raise ValueError("Downstream H3 Video Reference must use public tag <Video 1>.")
+        if role == "reference_audio" and tag != "<Audio 1>":
+            raise ValueError("Downstream H3 Reference Audio must use public tag <Audio 1>.")
+        if role == "driving_audio" and tag is not None:
+            raise ValueError("Downstream H3 Driving Audio does not own a public <Audio N> tag.")
+
+        item: dict[str, Any] = {
+            "role": role,
+            "kind": kind,
+            "source": source,
+            "visible_to_model": visible_to_model,
+        }
+        if tag:
+            item["tag"] = tag
+        for field in ("input_name", "source_node_id", "source_node_class", "source_output_name"):
+            field_value = raw.get(field)
+            if field_value is not None:
+                if not isinstance(field_value, (str, int)) or isinstance(field_value, bool):
+                    raise ValueError(
+                        f"Downstream H3 reference inventory item {offset} {field} must be text or an integer."
+                    )
+                item[field] = field_value
+        model_asset_id = raw.get("model_asset_id")
+        if model_asset_id is not None:
+            if not isinstance(model_asset_id, str) or not model_asset_id.strip():
+                raise ValueError(
+                    f"Downstream H3 reference inventory item {offset} model_asset_id must be non-empty text."
+                )
+            model_asset_id = model_asset_id.strip()
+            item["model_asset_id"] = model_asset_id
+        if visible_to_model != bool(model_asset_id):
+            raise ValueError(
+                f"Downstream H3 reference inventory item {offset} visible_to_model must be true exactly when model_asset_id is set."
+            )
+
+        source_slot = raw.get("source_slot")
+        if source_slot is not None:
+            if not isinstance(source_slot, int) or isinstance(source_slot, bool) or source_slot < 0:
+                raise ValueError(
+                    f"Downstream H3 reference inventory item {offset} source_slot must be a non-negative integer."
+                )
+            item["source_slot"] = source_slot
+
+        source_identity = raw.get("source_identity")
+        if source_identity is not None:
+            if not isinstance(source_identity, str) or not source_identity.strip():
+                raise ValueError(
+                    f"Downstream H3 reference inventory item {offset} source_identity must be non-empty text."
+                )
+            item["source_identity"] = source_identity.strip()
+        items.append(item)
+
+    reference_images = [item for item in items if item["role"] == "reference_image"]
+    first_frame = next((item for item in items if item["role"] == "first_frame"), None)
+    last_frame = next((item for item in items if item["role"] == "last_frame"), None)
+
+    expected_reference_tags = [f"<Picture {index}>" for index in range(1, len(reference_images) + 1)]
+    actual_reference_tags = [str(item.get("tag") or "") for item in reference_images]
+    if actual_reference_tags != expected_reference_tags:
+        raise ValueError(
+            "Downstream H3 Reference Images must use compact public tags <Picture 1> through <Picture N> "
+            "in active connection order."
+        )
+
+    if reference_images:
+        if any(item is not None and item.get("tag") for item in (first_frame, last_frame)):
+            raise ValueError(
+                "First/Last Frame must not own public <Picture N> tags when H3 Continuum Reference Images are active; "
+                "Continuum reserves public Picture numbering for the Reference Images in hybrid presentation."
+            )
+    else:
+        keyframes = [item for item in (first_frame, last_frame) if item is not None]
+        expected_keyframe_tags = [f"<Picture {index}>" for index in range(1, len(keyframes) + 1)]
+        actual_keyframe_tags = [str(item.get("tag") or "") for item in keyframes]
+        if actual_keyframe_tags != expected_keyframe_tags:
+            raise ValueError(
+                "Without H3 Continuum Reference Images, active First/Last Frame inputs must own compact public "
+                "<Picture 1> through <Picture N> tags in temporal order."
+            )
+
+    return {"schema_version": DOWNSTREAM_REFERENCE_SCHEMA_VERSION, "items": items}
+
+
+def downstream_reference_tags(request_input: dict[str, Any]) -> set[str]:
+    inventory = normalize_downstream_reference_inventory(
+        request_input.get("downstream_reference_inventory")
+    )
+    return {str(item["tag"]) for item in inventory["items"] if item.get("tag")}
+
+
+def effective_reference_tags(request_input: dict[str, Any], *, continuum: bool = False) -> set[str]:
+    assets = request_input.get("media_manifest", {}).get("assets", [])
+    manifest_tags = {
+        str(asset["reference"])
+        for asset in assets
+        if asset.get("reference")
+    }
+    if not continuum:
+        return manifest_tags
+
+    inventory_declared = "downstream_reference_inventory" in request_input
+    downstream = downstream_reference_tags(request_input)
+    if inventory_declared:
+        # Continuum's selected downstream workflow owns the public prompt identities.
+        # Prompt Writer media can be model-visible analysis without being a generation
+        # reference, so its manifest labels must not leak into the allowed Continuum set.
+        return downstream
+    return manifest_tags | downstream
+
+
+def missing_reference_declarations(
+    request_input: dict[str, Any],
+    texts: list[str],
+    *,
+    continuum: bool = False,
+) -> list[str]:
+    used: set[str] = set()
+    for text in texts:
+        used.update(reference_tags(str(text or "")))
+    return sorted(used - effective_reference_tags(request_input, continuum=continuum))
 
 
 @dataclass(frozen=True)
@@ -35,18 +233,26 @@ def reference_policy(request_input: dict[str, Any]) -> ReferencePolicy:
     if request_input.get("mode") != "Reference":
         return ReferencePolicy(set(), set(), set())
 
+    continuum = request_input.get("generation_target") == "continuum"
+    allowed = effective_reference_tags(request_input, continuum=continuum)
     assets = request_input.get("media_manifest", {}).get("assets", [])
-    allowed = {asset["reference"] for asset in assets if asset.get("reference")}
     required = {
-        asset["reference"]
+        str(asset["reference"])
         for asset in assets
         if asset.get("reference") and asset.get("type") != "audio"
     }
+    if continuum and "downstream_reference_inventory" in request_input:
+        required = {
+            tag for tag in allowed
+            if tag.startswith("<Picture ") or tag in {"<Video 1>", "<Audio 1>"}
+        }
     allowed_audio = {
-        asset["reference"]
+        str(asset["reference"])
         for asset in assets
         if asset.get("reference") and asset.get("type") == "audio"
     }
+    if continuum and "downstream_reference_inventory" in request_input:
+        allowed_audio = {tag for tag in allowed if tag.startswith("<Audio ")}
     if "instruction" not in request_input:
         brief_audio = canonical_reference_tags(str(request_input.get("creative_brief", "")), "Audio")
         required.update(brief_audio & allowed_audio)
@@ -60,3 +266,75 @@ def reference_policy(request_input: dict[str, Any]) -> ReferencePolicy:
     required.update((current_audio & allowed_audio) - mutable)
     required.difference_update(mutable)
     return ReferencePolicy(required, mutable, allowed)
+
+
+def bind_downstream_reference_inventory(
+    inventory: dict[str, Any] | None,
+    manifest: dict[str, Any],
+) -> dict[str, Any] | None:
+    if inventory is None:
+        return None
+    normalized = normalize_downstream_reference_inventory(inventory)
+    assets = {str(asset.get("id")): asset for asset in manifest.get("assets", []) if asset.get("id")}
+    seen_asset_ids: set[str] = set()
+    for item in normalized["items"]:
+        asset_id = item.get("model_asset_id")
+        if not asset_id:
+            continue
+        if asset_id in seen_asset_ids:
+            raise ValueError(f"Prompt Writer media asset {asset_id} is bound to more than one downstream H3 conditioning input.")
+        seen_asset_ids.add(asset_id)
+        asset = assets.get(asset_id)
+        if asset is None:
+            raise ValueError(
+                f"Downstream H3 conditioning item {item.get('tag') or item['role']} references missing Prompt Writer media asset {asset_id}."
+            )
+        if asset.get("type") != item["kind"]:
+            raise ValueError(
+                f"Prompt Writer media asset {asset_id} is {asset.get('type')!r}, but downstream role {item['role']!r} requires {item['kind']!r}."
+            )
+    return normalized
+
+
+def model_media_labels(
+    manifest: dict[str, Any],
+    inventory: dict[str, Any] | None,
+    *,
+    mode: str,
+) -> dict[str, str]:
+    assets = list(manifest.get("assets", []))
+    if inventory is None:
+        return {
+            str(asset["id"]): str(asset.get("reference") or asset.get("filename") or asset["id"])
+            for asset in assets
+            if asset.get("id")
+        }
+    bindings = {
+        str(item["model_asset_id"]): item
+        for item in inventory.get("items", [])
+        if item.get("model_asset_id")
+    }
+    counters = {"image": 0, "video": 0, "audio": 0}
+    labels: dict[str, str] = {}
+    role_labels = {
+        "first_frame": "Downstream First Frame",
+        "last_frame": "Downstream Last Frame",
+        "video_reference": "Downstream Video Reference",
+        "reference_audio": "Downstream Reference Audio",
+        "driving_audio": "Downstream Driving Audio",
+    }
+    for asset in assets:
+        asset_id = str(asset.get("id") or "")
+        if not asset_id:
+            continue
+        bound = bindings.get(asset_id)
+        if bound is not None:
+            labels[asset_id] = str(bound.get("tag") or role_labels.get(bound["role"]) or bound["role"])
+            continue
+        kind = str(asset.get("type") or "media")
+        if kind in counters:
+            counters[kind] += 1
+            labels[asset_id] = f"Analysis {kind} {counters[kind]} (no downstream public reference identity)"
+        else:
+            labels[asset_id] = f"Analysis media {asset_id} (no downstream public reference identity)"
+    return labels

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import shutil
 import threading
 import time
@@ -14,9 +15,36 @@ from server import PromptServer
 from .assembly import AssemblyError, assemble_lyrics_request, assemble_refinement, assemble_request
 from .catalog import discover_models_with_diagnostics, find_model, model_setup_catalog
 from .comfy_state import comfyui_runtime_snapshot
+from .continuum import (
+    GENERATION_TARGET_CONTINUUM,
+    ContinuumError,
+    apply_continuum_refinement,
+    assemble_continuum_chunk_request,
+    assemble_continuum_plan_repair_request,
+    assemble_continuum_plan_request,
+    assemble_continuum_refinement,
+    generation_target,
+    parse_sequence_plan,
+    recover_sequence_plan_contract,
+    persistent_reference_tags,
+    sequence_reference_scopes,
+    sequence_result,
+    stable_reference_tags,
+    validate_continuum_settings,
+    validate_generated_chunk,
+)
 from .devlog import DEVELOPER_MODE, LOG_PATH, PeakVRAMMonitor, gpu_memory_snapshot, write_event
 from .guides import MODE_GUIDES, guide_catalog, guide_for_mode
-from .media import CACHE_ROOT, MAX_FILE_BYTES, MODE_LIMITS, STORE, MediaError, parse_session_id
+from .media import (
+    CACHE_ROOT,
+    MAX_FILE_BYTES,
+    MODE_LIMITS,
+    STORE,
+    MediaError,
+    materialize_workflow_image,
+    normalize_workflow_materialization_plan,
+    parse_session_id,
+)
 from .memory import assess_free_vram
 from .models.gguf_backend import BACKEND as GGUF_BACKEND
 from .models.external_server_backend import BACKEND as EXTERNAL_SERVER_BACKEND
@@ -41,6 +69,8 @@ STATE: dict[str, Any] = {
     "pending_unload_model_id": None,
     "pending_unload_endpoint": None,
     "media_mutation_active": False,
+    "sequence_chunk_index": None,
+    "sequence_chunk_total": None,
 }
 STATE_LOCK = threading.RLock()
 
@@ -172,6 +202,8 @@ def _claim_generation_request() -> str | None:
             "pending_unload_family": None,
             "pending_unload_model_id": None,
             "pending_unload_endpoint": None,
+            "sequence_chunk_index": None,
+            "sequence_chunk_total": None,
         })
     return request_id
 
@@ -205,6 +237,13 @@ def _set_request_phase(request_id: str, phase: str) -> None:
             STATE["phase"] = phase
 
 
+def _set_sequence_progress(request_id: str, index: int | None, total: int | None) -> None:
+    with STATE_LOCK:
+        if STATE["active_request_id"] == request_id:
+            STATE["sequence_chunk_index"] = index
+            STATE["sequence_chunk_total"] = total
+
+
 def _release_generation_request(request_id: str) -> None:
     with STATE_LOCK:
         if STATE["active_request_id"] != request_id:
@@ -216,6 +255,8 @@ def _release_generation_request(request_id: str) -> None:
             "pending_unload_family": None,
             "pending_unload_model_id": None,
             "pending_unload_endpoint": None,
+            "sequence_chunk_index": None,
+            "sequence_chunk_total": None,
         })
 
 
@@ -380,17 +421,7 @@ async def _prepare_generation_runtime(
         backend.cancel()
         raise ModelError("GENERATION_CANCELLED", "Generation was cancelled.")
 
-    runtime_options = {
-        "context_profile": body.get("context_profile", "auto"),
-        "kv_cache": body.get("kv_cache", "auto"),
-        "thinking": body.get("thinking", False),
-    }
-    if model["family"] == "gguf":
-        runtime_options.update({
-            "context_tokens": body.get("context_tokens"),
-            "generation_budget": body.get("generation_budget"),
-            "reasoning_effort": body.get("reasoning_effort", "auto"),
-        })
+    runtime_options = _runtime_options(body, model)
     runtime_plan, cancellation = await _run_thread_worker(
         backend.preflight,
         model,
@@ -410,6 +441,41 @@ async def _prepare_generation_runtime(
                 pass
         raise
     return model, backend, runtime_plan
+
+
+def _runtime_options(body: dict[str, Any], model: dict[str, Any]) -> dict[str, Any]:
+    runtime_options = {
+        "context_profile": body.get("context_profile", "auto"),
+        "kv_cache": body.get("kv_cache", "auto"),
+        "thinking": body.get("thinking", False),
+    }
+    if model["family"] == "gguf":
+        runtime_options.update({
+            "context_tokens": body.get("context_tokens"),
+            "generation_budget": body.get("generation_budget"),
+            "reasoning_effort": body.get("reasoning_effort", "auto"),
+        })
+    return runtime_options
+
+
+async def _preflight_sequence_stage(
+    body: dict[str, Any],
+    model: dict[str, Any],
+    backend: Any,
+    assembled: dict[str, Any],
+    request_id: str,
+) -> dict[str, Any]:
+    runtime_plan, cancellation = await _run_thread_worker(
+        backend.preflight,
+        model,
+        assembled,
+        **_runtime_options(body, model),
+    )
+    _propagate_worker_cancellation(cancellation)
+    await _memory_preflight(backend, model, runtime_plan)
+    if _request_cancelled(request_id):
+        raise ModelError("GENERATION_CANCELLED", "Generation was cancelled.")
+    return runtime_plan
 
 
 def _model_error_status(error: ModelError) -> int:
@@ -445,6 +511,16 @@ def _model_error_status(error: ModelError) -> int:
         "API_REQUEST_TIMEOUT",
         "API_RESPONSE_INVALID",
         "API_GENERATION_FAILED",
+        "INVALID_CONTINUUM_PLAN",
+        "INVALID_CONTINUUM_PLAN_CHUNKS",
+        "INVALID_CONTINUUM_PLAN_CONTINUITY",
+        "INVALID_CONTINUUM_PLAN_REFERENCES",
+        "INVALID_CONTINUUM_CHUNK_FORMAT",
+        "EMPTY_CONTINUUM_CHUNK",
+        "INVALID_CONTINUUM_SEQUENCE",
+        "CONTINUUM_REFERENCE_IDENTITY_DRIFT",
+        "CONTINUUM_REFERENCE_SCOPE_DRIFT",
+        "CONTINUUM_SUBJECT_IDENTITY_DRIFT",
     }:
         return 502
     return 400
@@ -467,6 +543,381 @@ async def _json_body(request: web.Request) -> dict[str, Any] | None:
     except (ValueError, TypeError):
         return None
     return body if isinstance(body, dict) else None
+
+
+async def _run_generation_stage(
+    *,
+    body: dict[str, Any],
+    model: dict[str, Any],
+    backend: Any,
+    assembled: dict[str, Any],
+    runtime_plan: dict[str, Any],
+    seed: int | None,
+    unload_after: bool,
+    on_phase: Callable[[str], None],
+) -> dict[str, Any]:
+    result, cancellation = await _run_thread_worker(
+        backend.generate,
+        model,
+        assembled,
+        body["session_id"],
+        on_cancel=backend.cancel,
+        thinking=body.get("thinking", False),
+        seed=seed,
+        unload_after=unload_after,
+        context_profile=body.get("context_profile", "auto"),
+        kv_cache=body.get("kv_cache", "auto"),
+        runtime_plan=runtime_plan,
+        on_phase=on_phase,
+    )
+    _propagate_worker_cancellation(cancellation)
+    return result
+
+
+def _sequence_seed(seed: int | None, stage: int) -> int | None:
+    if seed is None:
+        return None
+    return (int(seed) + 0x9E3779B1 * int(stage)) & 0x7FFFFFFF
+
+
+def _aggregate_sequence_metrics(results: list[dict[str, Any]]) -> dict[str, Any]:
+    if not results:
+        return {}
+    final = results[-1]
+    generation_seconds = sum(float(item.get("generation_seconds") or 0) for item in results)
+    output_tokens = sum(int(item.get("output_tokens") or 0) for item in results)
+    aggregated: dict[str, Any] = {
+        "input_tokens": sum(int(item.get("input_tokens") or 0) for item in results),
+        "output_tokens": output_tokens,
+        "generation_seconds": round(generation_seconds, 3),
+        "media_processing_seconds": round(
+            sum(float(item.get("media_processing_seconds") or 0) for item in results), 3
+        ),
+        "visual_input_count": sum(int(item.get("visual_input_count") or 0) for item in results),
+        "video_frame_count": sum(int(item.get("video_frame_count") or 0) for item in results),
+        "video_sheet_count": sum(int(item.get("video_sheet_count") or 0) for item in results),
+        "thinking_fallback": any(bool(item.get("thinking_fallback")) for item in results),
+        "thinking_attempt_tokens": sum(int(item.get("thinking_attempt_tokens") or 0) for item in results),
+        "reasoning_tokens": sum(int(item.get("reasoning_tokens") or 0) for item in results),
+        "cold_start": any(bool(item.get("cold_start")) for item in results),
+        "model_load_seconds": round(sum(float(item.get("model_load_seconds") or 0) for item in results), 3),
+        "context_tokens": max(int(item.get("context_tokens") or 0) for item in results),
+        "max_output_tokens": max(int(item.get("max_output_tokens") or 0) for item in results),
+        "thinking_budget_reduced": any(bool(item.get("thinking_budget_reduced")) for item in results),
+        "tokens_per_second": round(output_tokens / generation_seconds, 2) if generation_seconds > 0 else 0,
+        "sequence_request_count": len(results),
+    }
+    for key in (
+        "context_profile",
+        "kv_cache",
+        "text_token_source",
+        "api_provider",
+        "external_server",
+        "provider_request_count",
+        "usage_source",
+        "provider_request_ids",
+        "provider_cost_usd",
+        "upstream_providers",
+    ):
+        if key in final:
+            aggregated[key] = final[key]
+    return aggregated
+
+
+async def _unload_failed_sequence(
+    backend: Any,
+    model: dict[str, Any],
+    body: dict[str, Any],
+) -> None:
+    if not body.get("unload_after", True) or getattr(backend, "externally_managed", False):
+        return
+    try:
+        if model.get("family") == "ollama":
+            await _run_thread_worker(
+                backend.unload,
+                model.get("remote_model"),
+                model.get("endpoint") or body.get("ollama_host"),
+            )
+        else:
+            await _run_thread_worker(backend.unload)
+    except BaseException:
+        pass
+
+
+async def _generate_continuum(
+    body: dict[str, Any],
+    planner_assembled: dict[str, Any],
+    settings: dict[str, Any],
+) -> web.Response:
+    request_id = _claim_generation_request()
+    if request_id is None:
+        return _error("GENERATION_BUSY", "Another H3 Prompt Writer request is already running.", status=409)
+    model: dict[str, Any] | None = None
+    backend: Any = None
+    request_started = time.perf_counter()
+    vram_monitor = PeakVRAMMonitor()
+    vram_monitor.start()
+    stage = {"kind": "plan", "chunk": None}
+
+    def on_phase(phase: str) -> None:
+        if phase == "generating":
+            visible_phase = "planning_sequence" if stage["kind"] in {"plan", "plan_repair"} else "generating_chunk"
+        elif phase == "processing_media" and stage["kind"] in {"plan", "plan_repair"}:
+            visible_phase = "planning_sequence"
+        else:
+            visible_phase = phase
+        _set_request_phase(request_id, visible_phase)
+        write_event(
+            "phase",
+            request_id=request_id,
+            operation="generate_continuum",
+            phase=visible_phase,
+            stage=stage["kind"],
+            chunk_index=stage["chunk"],
+            elapsed_seconds=round(time.perf_counter() - request_started, 3),
+        )
+
+    try:
+        model, backend, planner_runtime = await _prepare_generation_runtime(body, planner_assembled, request_id)
+        write_event(
+            "request_started",
+            request_id=request_id,
+            operation="generate_continuum",
+            model={"id": model["id"], "name": model["name"], "family": model["family"], "format": model.get("format")},
+            thinking=body.get("thinking", False),
+            seed=body.get("seed"),
+            unload_after=body.get("unload_after", True),
+            context_profile=planner_runtime["context_profile"],
+            kv_cache=planner_runtime["kv_cache"],
+            input=planner_assembled["input"],
+        )
+        stage_results: list[dict[str, Any]] = []
+        planner_result = await _run_generation_stage(
+            body=body,
+            model=model,
+            backend=backend,
+            assembled=planner_assembled,
+            runtime_plan=planner_runtime,
+            seed=_sequence_seed(body.get("seed"), 0),
+            unload_after=False,
+            on_phase=on_phase,
+        )
+        stage_results.append(planner_result)
+        expected_references = stable_reference_tags(planner_assembled["input"])
+        persistent_references = persistent_reference_tags(
+            planner_assembled["input"],
+            chunks=settings["chunks"],
+        )
+        chunk_reference_scopes = sequence_reference_scopes(
+            planner_assembled["input"],
+            chunks=settings["chunks"],
+        )
+        planner_repair_attempted = False
+        planner_contract_recovery_actions: list[str] = []
+        try:
+            plan = parse_sequence_plan(
+                planner_result["prompt"],
+                settings,
+                expected_references=expected_references,
+                persistent_references=persistent_references,
+                chunk_reference_scopes=chunk_reference_scopes,
+            )
+        except ContinuumError as first_error:
+            try:
+                plan, planner_contract_recovery_actions = recover_sequence_plan_contract(
+                    planner_result["prompt"],
+                    settings,
+                    expected_references=expected_references,
+                    persistent_references=persistent_references,
+                    chunk_reference_scopes=chunk_reference_scopes,
+                )
+            except ContinuumError:
+                planner_repair_attempted = True
+                stage.update({"kind": "plan_repair", "chunk": None})
+                repair_assembled = assemble_continuum_plan_repair_request(
+                    body,
+                    planner_result["prompt"],
+                    first_error,
+                )
+                repair_runtime = await _preflight_sequence_stage(
+                    body, model, backend, repair_assembled, request_id
+                )
+                repair_result = await _run_generation_stage(
+                    body=body,
+                    model=model,
+                    backend=backend,
+                    assembled=repair_assembled,
+                    runtime_plan=repair_runtime,
+                    seed=_sequence_seed(body.get("seed"), 1),
+                    unload_after=False,
+                    on_phase=on_phase,
+                )
+                stage_results.append(repair_result)
+                try:
+                    plan = parse_sequence_plan(
+                        repair_result["prompt"],
+                        settings,
+                        expected_references=expected_references,
+                        persistent_references=persistent_references,
+                        chunk_reference_scopes=chunk_reference_scopes,
+                    )
+                except ContinuumError as second_error:
+                    try:
+                        plan, planner_contract_recovery_actions = recover_sequence_plan_contract(
+                            repair_result["prompt"],
+                            settings,
+                            expected_references=expected_references,
+                            persistent_references=persistent_references,
+                            chunk_reference_scopes=chunk_reference_scopes,
+                        )
+                    except ContinuumError as recovery_error:
+                        raise ModelError(
+                            second_error.code,
+                            "The sequence planner remained invalid after one bounded complete-contract repair "
+                            "and deterministic contract recovery.",
+                            {
+                                "initial_error": {
+                                    "code": first_error.code,
+                                    "message": first_error.message,
+                                    "details": first_error.details,
+                                },
+                                "repair_error": {
+                                    "code": second_error.code,
+                                    "message": second_error.message,
+                                    "details": second_error.details,
+                                },
+                                "recovery_error": {
+                                    "code": recovery_error.code,
+                                    "message": recovery_error.message,
+                                    "details": recovery_error.details,
+                                },
+                            },
+                        ) from recovery_error
+
+        prompts: list[str] = []
+        chunk_results: list[dict[str, Any]] = []
+        seed_stage_offset = 2 if planner_repair_attempted else 1
+        for index in range(1, settings["chunks"] + 1):
+            stage.update({"kind": "chunk", "chunk": index})
+            _set_sequence_progress(request_id, index, settings["chunks"])
+            if _request_cancelled(request_id):
+                raise ModelError("GENERATION_CANCELLED", "Generation was cancelled.")
+            try:
+                assembled = assemble_continuum_chunk_request(
+                    body,
+                    plan,
+                    index,
+                    previous_prompt=prompts[-1] if prompts else None,
+                )
+                runtime_plan = await _preflight_sequence_stage(
+                    body, model, backend, assembled, request_id
+                )
+                result = await _run_generation_stage(
+                    body=body,
+                    model=model,
+                    backend=backend,
+                    assembled=assembled,
+                    runtime_plan=runtime_plan,
+                    seed=_sequence_seed(body.get("seed"), seed_stage_offset + index - 1),
+                    unload_after=bool(body.get("unload_after", True) and index == settings["chunks"]),
+                    on_phase=on_phase,
+                )
+                prompt = validate_generated_chunk(result["prompt"], assembled)
+            except ContinuumError as error:
+                raise ModelError(
+                    error.code,
+                    f"Continuum generation failed at Chunk {index}: {error.message}",
+                    {"chunk_index": index, "continuum_error": error.details},
+                ) from error
+            except ModelError as error:
+                if error.code == "GENERATION_CANCELLED":
+                    raise
+                raise ModelError(
+                    error.code,
+                    f"Continuum generation failed at Chunk {index}: {error.message}",
+                    {"chunk_index": index, "cause": error.details},
+                ) from error
+            prompts.append(prompt)
+            stage_results.append(result)
+            chunk_results.append({
+                "index": index,
+                "prompt_audit": result.get("prompt_audit"),
+                "format_repair_attempted": bool(result.get("format_repair_attempted")),
+                "format_repair_applied": bool(result.get("format_repair_applied")),
+                "format_repair_failure": result.get("format_repair_failure"),
+            })
+
+        sequence = sequence_result(
+            settings,
+            plan,
+            prompts,
+            downstream_reference_inventory=planner_assembled["input"]["downstream_reference_inventory"],
+        )
+        total_seconds = round(time.perf_counter() - request_started, 3)
+        peak_vram_mb = vram_monitor.stop()
+        metrics = _aggregate_sequence_metrics(stage_results)
+        response = {
+            "request_id": request_id,
+            "model_id": model["id"],
+            "thinking": body.get("thinking", False),
+            "generation_target": GENERATION_TARGET_CONTINUUM,
+            "total_seconds": total_seconds,
+            "peak_vram_mb": peak_vram_mb,
+            "prompt": sequence["prompt"],
+            "sequence": sequence,
+            "planner_repair_attempted": planner_repair_attempted,
+            "planner_contract_recovery_applied": bool(planner_contract_recovery_actions),
+            "planner_contract_recovery_actions": planner_contract_recovery_actions,
+            "chunk_results": chunk_results,
+            **metrics,
+        }
+        write_event(
+            "request_succeeded",
+            request_id=request_id,
+            operation="generate_continuum",
+            total_seconds=total_seconds,
+            peak_vram_mb=peak_vram_mb,
+            metrics=metrics,
+            chunks=settings["chunks"],
+            chunk_seconds=settings["chunk_seconds"],
+            output=sequence["prompt"],
+        )
+        return web.json_response(response)
+    except (ContinuumError, AssemblyError) as error:
+        wrapped = ModelError(error.code, error.message, error.details)
+        if backend is not None and model is not None:
+            await _unload_failed_sequence(backend, model, body)
+        peak_vram_mb = vram_monitor.stop()
+        write_event(
+            "request_failed",
+            request_id=request_id,
+            operation="generate_continuum",
+            total_seconds=round(time.perf_counter() - request_started, 3),
+            peak_vram_mb=peak_vram_mb,
+            error={"code": wrapped.code, "message": wrapped.message, "details": wrapped.details},
+        )
+        return _error(wrapped.code, wrapped.message, status=_model_error_status(wrapped), details=wrapped.details)
+    except ModelError as error:
+        if backend is not None and model is not None:
+            await _unload_failed_sequence(backend, model, body)
+        peak_vram_mb = vram_monitor.stop()
+        write_event(
+            "request_failed",
+            request_id=request_id,
+            operation="generate_continuum",
+            total_seconds=round(time.perf_counter() - request_started, 3),
+            peak_vram_mb=peak_vram_mb,
+            error={"code": error.code, "message": error.message, "details": error.details},
+        )
+        status = 499 if error.code == "GENERATION_CANCELLED" else _model_error_status(error)
+        return _error(error.code, error.message, status=status, details=error.details)
+    except BaseException:
+        if backend is not None and model is not None:
+            await _unload_failed_sequence(backend, model, body)
+        raise
+    finally:
+        vram_monitor.stop()
+        _release_generation_request(request_id)
 
 
 routes = PromptServer.instance.routes
@@ -496,7 +947,14 @@ async def get_status(request: web.Request) -> web.Response:
     else:
         backend_status = await asyncio.to_thread(backend.status)
     return web.json_response({
-        **{key: state[key] for key in ("phase", "active_request_id", "selected_model_id", "selected_model_family")},
+        **{key: state[key] for key in (
+            "phase",
+            "active_request_id",
+            "selected_model_id",
+            "selected_model_family",
+            "sequence_chunk_index",
+            "sequence_chunk_total",
+        )},
         **backend_status,
         "backend_ready": True,
         "model_backend_ready": True,
@@ -658,10 +1116,25 @@ async def generate(request: web.Request) -> web.Response:
     if body["mode"] not in MODES:
         return _error("INVALID_MODE", "The selected MiniMax mode is not supported.", status=400)
 
+    try:
+        target = generation_target(body)
+    except ContinuumError as error:
+        return _error(error.code, error.message, status=400, details=error.details)
+
     if not isinstance(body.get("thinking", False), bool) or not isinstance(body.get("unload_after", True), bool):
         return _error("INVALID_REQUEST", "Thinking and unload_after must be booleans.", status=400)
     if body.get("seed") is not None and (not isinstance(body["seed"], int) or isinstance(body["seed"], bool) or body["seed"] < 0):
         return _error("INVALID_REQUEST", "Seed must be a non-negative integer.", status=400)
+    if target == GENERATION_TARGET_CONTINUUM:
+        try:
+            settings = validate_continuum_settings(body)
+            planner_assembled = assemble_continuum_plan_request(body)
+        except (ContinuumError, AssemblyError) as error:
+            return _error(error.code, error.message, status=400, details=error.details)
+        except (MediaError, RuntimeError) as error:
+            code = error.code if isinstance(error, MediaError) else "GUIDE_LOAD_FAILED"
+            return _error(code, str(error), status=500)
+        return await _generate_continuum(body, planner_assembled, settings)
     try:
         assembled = assemble_request(body)
     except AssemblyError as error:
@@ -841,6 +1314,10 @@ async def refine(request: web.Request) -> web.Response:
     body = await _json_body(request)
     if body is None:
         return _error("INVALID_REQUEST", "Expected a JSON object.", status=400)
+    try:
+        target = generation_target(body)
+    except ContinuumError as error:
+        return _error(error.code, error.message, status=400, details=error.details)
     lyrics_request = body.get("mode") == "Music3" and body.get("target") == "lyrics"
     required = ("model_id", "session_id", "mode") if lyrics_request else ("current_prompt", "instruction", "model_id", "session_id", "mode")
     missing = [key for key in required if not body.get(key)]
@@ -850,12 +1327,17 @@ async def refine(request: web.Request) -> web.Response:
         return _error("INVALID_REQUEST", "Thinking and unload_after must be booleans.", status=400)
     if body.get("seed") is not None and (not isinstance(body["seed"], int) or isinstance(body["seed"], bool) or body["seed"] < 0):
         return _error("INVALID_REQUEST", "Seed must be a non-negative integer.", status=400)
+    continuum_refinement: tuple[dict[str, Any], int, dict[str, Any]] | None = None
     try:
-        assembled = assemble_lyrics_request(body) if lyrics_request else assemble_refinement(
-            body,
-            _get_generation_cache(body["session_id"], body["mode"]),
-        )
-    except AssemblyError as error:
+        if target == GENERATION_TARGET_CONTINUUM:
+            assembled, sequence_state, chunk_index, sequence_plan = assemble_continuum_refinement(body)
+            continuum_refinement = (sequence_state, chunk_index, sequence_plan)
+        else:
+            assembled = assemble_lyrics_request(body) if lyrics_request else assemble_refinement(
+                body,
+                _get_generation_cache(body["session_id"], body["mode"]),
+            )
+    except (AssemblyError, ContinuumError) as error:
         return _error(error.code, error.message, status=400, details=error.details)
     except (MediaError, RuntimeError) as error:
         code = error.code if isinstance(error, MediaError) else "GUIDE_LOAD_FAILED"
@@ -914,6 +1396,23 @@ async def refine(request: web.Request) -> web.Response:
         _propagate_worker_cancellation(cancellation)
         if lyrics_request and len(result["prompt"]) > 4000:
             raise ModelError("LYRICS_TOO_LONG", "The generated Lyrics exceed 4,000 characters. Shorten the request and try again.")
+        if continuum_refinement is not None:
+            sequence_state, chunk_index, sequence_plan = continuum_refinement
+            try:
+                sequence = apply_continuum_refinement(
+                    result["prompt"],
+                    assembled,
+                    sequence_state,
+                    chunk_index,
+                    sequence_plan,
+                )
+            except ContinuumError as error:
+                raise ModelError(error.code, error.message, error.details) from error
+            result["chunk_prompt"] = sequence["chunks"][chunk_index - 1]["prompt"]
+            result["chunk_index"] = chunk_index
+            result["prompt"] = sequence["prompt"]
+            result["sequence"] = sequence
+            result["generation_target"] = GENERATION_TARGET_CONTINUUM
         total_seconds = round(time.perf_counter() - request_started, 3)
         peak_vram_mb = vram_monitor.stop()
         debug_input_sequence = result.pop("debug_input_sequence", None)
@@ -936,6 +1435,13 @@ async def refine(request: web.Request) -> web.Response:
             **result,
         })
     except ModelError as error:
+        if continuum_refinement is not None and error.code != "GENERATION_CANCELLED":
+            chunk_index = continuum_refinement[1]
+            error = ModelError(
+                error.code,
+                f"Continuum refinement failed at Chunk {chunk_index}: {error.message}",
+                {"chunk_index": chunk_index, "cause": error.details},
+            )
         peak_vram_mb = vram_monitor.stop()
         write_event(
             "request_failed",
@@ -950,6 +1456,142 @@ async def refine(request: web.Request) -> web.Response:
     finally:
         vram_monitor.stop()
         _release_generation_request(request_id)
+
+
+@routes.post(f"{ROUTE_PREFIX}/media/materialize-workflow-image")
+async def materialize_workflow_reference_media(request: web.Request) -> web.Response:
+    busy = _generation_busy_error()
+    if busy is not None:
+        return busy
+    try:
+        reader = await request.multipart()
+    except Exception:
+        return _error("INVALID_REQUEST", "Expected multipart form data.", status=400)
+
+    session_id: str | None = None
+    mode: str | None = None
+    plan: dict[str, Any] | None = None
+    source_path: Path | None = None
+    asset_dir: Path | None = None
+    media_claimed = False
+    replace_asset_id: str | None = request.query.get("replace_asset_id") or None
+    source_filename = "workflow-reference.png"
+
+    def rollback() -> None:
+        if asset_dir is not None:
+            shutil.rmtree(asset_dir, ignore_errors=True)
+
+    try:
+        while field := await reader.next():
+            if field.name == "session_id":
+                session_id = parse_session_id((await field.text()).strip() or None)
+                continue
+            if field.name == "mode":
+                mode = (await field.text()).strip()
+                continue
+            if field.name == "replace_asset_id":
+                replace_asset_id = (await field.text()).strip() or None
+                continue
+            if field.name == "materialization_plan":
+                try:
+                    plan = normalize_workflow_materialization_plan(json.loads(await field.text()))
+                except json.JSONDecodeError as error:
+                    raise MediaError(
+                        "INVALID_WORKFLOW_MATERIALIZATION",
+                        "Workflow image materialization plan is not valid JSON.",
+                    ) from error
+                continue
+            if field.name != "file" or not field.filename:
+                continue
+            if source_path is not None:
+                raise MediaError("INVALID_WORKFLOW_MATERIALIZATION", "Workflow materialization accepts exactly one source image.")
+            if session_id is None:
+                session_id = parse_session_id(None)
+            if mode != "Reference":
+                raise MediaError(
+                    "INVALID_MODE",
+                    "Workflow image materialization is only available in Reference mode.",
+                )
+            asset_dir = CACHE_ROOT / session_id / str(uuid4())
+            asset_dir.mkdir(parents=True, exist_ok=False)
+            extension = Path(field.filename).suffix.lower() or ".img"
+            source_path = asset_dir / f"workflow_source{extension}"
+            source_filename = Path(field.filename).name or "workflow-reference.png"
+            size = 0
+            with source_path.open("wb") as output:
+                while chunk := await field.read_chunk(1024 * 1024):
+                    size += len(chunk)
+                    if size > MAX_FILE_BYTES:
+                        raise MediaError("MEDIA_TOO_LARGE", "A media file cannot exceed 1 GB.")
+                    output.write(chunk)
+
+        if session_id is None or source_path is None or asset_dir is None:
+            raise MediaError("INVALID_REQUEST", "Workflow materialization requires one source image.")
+        if mode != "Reference":
+            raise MediaError("INVALID_MODE", "Workflow image materialization is only available in Reference mode.")
+        if plan is None:
+            raise MediaError("INVALID_WORKFLOW_MATERIALIZATION", "Workflow image materialization plan is missing.")
+        if not _claim_media_mutation():
+            raise MediaError("GENERATION_BUSY", "Media cannot be changed while H3 Prompt Writer is generating or refining.")
+        media_claimed = True
+
+        target_path = asset_dir / "original.png"
+        _materialized, cancellation = await _run_thread_worker(
+            materialize_workflow_image,
+            source_path,
+            target_path,
+            plan,
+        )
+        _propagate_worker_cancellation(cancellation)
+        source_path.unlink(missing_ok=True)
+        materialized_filename = f"{Path(source_filename).stem or 'workflow-reference'}-materialized.png"
+
+        if replace_asset_id:
+            old_asset = STORE.get(session_id, replace_asset_id)
+            if old_asset["mode"] != "Reference":
+                raise MediaError("INVALID_REPLACEMENT", "The replacement must stay in Reference mode.")
+            prepared, cancellation = await _run_thread_worker(
+                STORE.prepare_replace,
+                session_id,
+                replace_asset_id,
+                materialized_filename,
+                "image/png",
+                target_path,
+            )
+            _propagate_worker_cancellation(cancellation)
+            asset = STORE.commit_replace(session_id, replace_asset_id, prepared)
+            asset_dir = None
+            _invalidate_generation_cache(session_id, "Reference")
+            return web.json_response(
+                {"session_id": session_id, "asset": asset, "assets": STORE.list(session_id)},
+                status=201,
+            )
+
+        prepared, cancellation = await _run_thread_worker(
+            STORE.prepare_add,
+            session_id,
+            "Reference",
+            materialized_filename,
+            "image/png",
+            target_path,
+        )
+        _propagate_worker_cancellation(cancellation)
+        asset = STORE.commit_add(session_id, "Reference", prepared)
+        asset_dir = None
+        _invalidate_generation_cache(session_id, "Reference")
+        return web.json_response({"session_id": session_id, "assets": [asset]}, status=201)
+    except (MediaError, ValueError) as error:
+        rollback()
+        if isinstance(error, MediaError):
+            status = 409 if error.code == "GENERATION_BUSY" else 400
+            return _media_error(error, status=status)
+        return _error("INVALID_SESSION", "The media session ID is invalid.", status=400)
+    except BaseException:
+        rollback()
+        raise
+    finally:
+        if media_claimed:
+            _release_media_mutation()
 
 
 @routes.post(f"{ROUTE_PREFIX}/media/upload")

--- a/docs/DIRECT_GGUF.md
+++ b/docs/DIRECT_GGUF.md
@@ -14,7 +14,7 @@ This is an optional advanced path. Most users should start with [Ollama](OLLAMA.
 - One supported model GGUF.
 - For image and video-reference modes, the matching multimodal projector (`mmproj`) from the same model class.
 
-A model without an active projector remains usable as text-only Direct GGUF. Writer keeps T2VA and Refine available, disables I2VA, FL2VA, L2VA, Reference, and Music 3, and shows why vision is unavailable.
+A model without an active projector remains usable as text-only Direct GGUF. Writer keeps T2VA available and also permits H3 Continuum I2VA, FL2VA, L2VA, or Reference when all visual conditioning comes from the selected V3.4 workflow and Prompt Writer sends no image/video pixels. Chunk-local Continuum Refine is also text-only because it does not re-upload the original analysis media. Ordinary visual I2VA/FL2VA/L2VA/Reference requests and Music 3 remain unavailable on this Direct model.
 
 Workflow safetensors, checkpoints, and text encoders are unrelated to the Direct prompt model.
 
@@ -61,7 +61,7 @@ ComfyUI/models/LLM/
     └── mmproj-Qwen3VL-8B-Instruct-Q8_0.gguf
 ```
 
-Do not share a projector across incompatible model classes because the filenames happen to match. Writer reads the GGUF metadata to distinguish models from projectors, so a projector does not need `mmproj` in its filename. The filename is only an Extension compatibility hint when metadata cannot be read. Writer enables vision only when it finds one metadata-compatible projector for a model. A missing or ambiguous projector does not hide the model; it leaves the model available in text-only T2VA mode and reports the pairing problem in Direct settings and Scan details.
+Do not share a projector across incompatible model classes because the filenames happen to match. Writer reads the GGUF metadata to distinguish models from projectors, so a projector does not need `mmproj` in its filename. The filename is only an Extension compatibility hint when metadata cannot be read. Writer enables vision only when it finds one metadata-compatible projector for a model. A missing or ambiguous projector does not hide the model; it leaves text-only T2VA plus workflow-only H3 Continuum available and reports the pairing problem in Direct settings and Scan details.
 
 Select **Refresh** after adding files. Expand **Scan details** if the model does not appear.
 

--- a/docs/EXTERNAL_LLAMA_SERVER.md
+++ b/docs/EXTERNAL_LLAMA_SERVER.md
@@ -16,7 +16,7 @@ External llama.cpp is the advanced local provider for users who want to control 
 
 On Linux or macOS, use `./llama-server` and the appropriate file paths.
 
-For Music 3, T2VA, and Refine, you can run the same model without `--mmproj`:
+For Music 3, T2VA, ordinary text-only Refine, and workflow-only H3 Continuum, you can run the same model without `--mmproj`:
 
 ```powershell
 .\llama-server.exe -m "C:\models\model.gguf" --host 127.0.0.1 --port 8080 --ctx-size 24576 --alias prompt-writer
@@ -57,9 +57,9 @@ http://127.0.0.1:8080
 
 Entering `http://127.0.0.1:8080/v1` is also accepted and normalized to the server root. Arbitrary additional paths are rejected.
 
-During connection, Writer checks `/health`, `/props`, and `/v1/models`. A text-only model can connect and handle Music 3, T2VA, and Refine.
+During connection, Writer checks `/health`, `/props`, and `/v1/models`. A text-only model can connect and handle Music 3, T2VA, ordinary text-only Refine, and H3 Continuum requests whose visual conditioning remains workflow-only.
 
-I2VA, FL2VA, L2VA, and Reference requests with images or video need vision support from a matching model and projector. If a text-only model receives visual media, Writer stops before generation and explains how to enable vision.
+Prompt Writer requests that actually attach images or video for model analysis need vision support from a matching model and projector, including visual I2VA, FL2VA, L2VA, and Reference. Workflow-only H3 Continuum conditioning is metadata and does not itself require `--mmproj`. If a text-only model receives visual analysis media, Writer stops before generation and explains how to enable vision.
 
 ## Advanced use
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -37,7 +37,7 @@ Choose External if you already use llama.cpp or want your own current/custom bui
 
 External has its own local provider path and is the recommended advanced alternative when the Direct Python runtime is incompatible with a system.
 
-A text-only server works with Music 3, T2VA, and Refine. Add the model's matching `mmproj` when Writer needs to read images or video.
+A text-only server works with Music 3, T2VA, ordinary text-only Refine, and workflow-only H3 Continuum. Add the model's matching `mmproj` when Prompt Writer itself needs to read images or video.
 
 ## API providers
 
@@ -46,3 +46,13 @@ Choose an API provider if you do not want a local prompt-model runtime. Gemini, 
 Remote providers receive the brief, H3 instructions, and prepared visual inputs from the current mode's manifest. Read [API providers](API_PROVIDERS.md#what-leaves-this-computer) before connecting a remote service.
 
 Comfy Cloud has not been validated for v0.3.
+
+## H3 Continuum request budgeting
+
+A Continuum sequence is not one prompt-model call. Writer normally makes one planning call plus one call for every chunk. A structurally invalid plan gets at most one narrow repair call. Existing H3 format repair can add a correction call for an individual chunk when its first draft fails an objective check.
+
+For Direct, Ollama, and External llama.cpp, expect proportionally longer runtime. Writer keeps one admitted request and reuses the selected backend through the stages; **Cancel** stops the sequence at the next safe point. **Keep model loaded** still controls the final lifecycle decision for Writer-managed local providers.
+
+For a paid API provider, every provider call can consume quota and incur cost. The result reports the provider's cumulative request count, request IDs, and reported cost when the endpoint supplies them. Confirm current provider pricing and limits before generating a large sequence.
+
+Continuum's downstream conditioning inventory is metadata. A workflow Reference Image can be declared to the planner without uploading its pixels to the prompt model. This lets text-only prompt models plan around known `<Picture N>` roles when the Creative Brief describes those roles. If Prompt Writer also sends real images or video contact sheets for analysis, the selected provider still needs the corresponding visual capability and receives those prepared visual inputs under the normal provider privacy rules.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -149,7 +149,7 @@ Without an unambiguous compatible projector, the model remains available for T2V
 
 **Verify**
 
-The model appears under **Installed models**. A text-only setup completes a T2VA request; a paired vision setup also completes a real image request.
+The model appears under **Installed models**. A text-only setup completes T2VA and workflow-only H3 Continuum requests; a paired vision setup also completes a real Prompt Writer image-analysis request.
 
 ## Ollama is not running
 
@@ -215,7 +215,7 @@ An input ending in `/v1` is accepted and normalized. Remove any other added path
 
 **Verify**
 
-External Settings show the connected model. A text-only model is ready for Music 3, T2VA, and Refine. If you started the server with a projector, confirm vision with a real image request.
+External Settings show the connected model. A text-only model is ready for Music 3, T2VA, ordinary text-only Refine, and workflow-only H3 Continuum. If you started the server with a projector, confirm vision with a real image request.
 
 ## Vision is unavailable
 
@@ -229,11 +229,101 @@ The loaded model is text-only, its matching projector is missing, or the OpenAI-
 
 **Fix**
 
-For External llama.cpp, restart with the model's matching `--mmproj`. You can keep using a text-only server for Music 3, T2VA, and Refine. For local LM Studio, load a vision model before reconnecting. For another Custom endpoint, enable **Endpoint accepts image_url inputs** only when both server and model support that contract.
+For External llama.cpp, restart with the model's matching `--mmproj`. You can keep using a text-only server for Music 3, T2VA, ordinary text-only Refine, and workflow-only H3 Continuum. For local LM Studio, load a vision model before reconnecting. For another Custom endpoint, enable **Endpoint accepts image_url inputs** only when both server and model support that contract.
 
 **Verify**
 
 The selected model shows **Vision** and completes a real image request.
+
+## Continuum sequence or handoff failure
+
+**Symptom**
+
+Writer rejects a sequence plan, reports a failure at a specific chunk, cannot find a sampler, asks you to select one sampler, or says the Sequence Prompt source is not editable.
+
+**Cause**
+
+The prompt model returned an invalid semantic plan or chunk body; the Timeline text no longer has exact contiguous boundaries; the configured values are outside H3 Continuum's native 1–16 chunks and 4–30 seconds per chunk; the selected sampler is not using **Prompt Format = Timeline**; or the workflow does not expose one unambiguous a supported **H3 Continuum Sampler V3.4–V3.7** connected to an editable **Text (Multiline)** source.
+
+**Fix**
+
+Review the reported chunk and clarify the Creative Brief. A malformed plan receives one automatic structural repair; a second invalid plan stops instead of being guessed. Keep the shared preamble before the first Timeline header and keep every `[start-end]` header on its own line with exact boundaries derived from the configured chunk duration. Add or select exactly one compatible H3 Continuum sampler and connect an editable Text (Multiline) node to **Sequence Prompt**. When Prompt Format, chunk count, or chunk duration differs, review the proposed values before using **Sync settings & apply**.
+
+**Verify**
+
+The complete canonical Timeline appears in the connected text widget, **Prompt Format** is **Timeline**, sampler chunk values match Writer, Continuum resolves every section with the shared preamble, and the workflow accepts the prompt without Fixed fallback or parser warnings.
+
+## Continuum sampler not found during generation or refinement
+
+**Symptom**
+
+Writer reports **Continuum sampler not found** before sequence generation or chunk refinement starts.
+
+**Cause**
+
+Continuum prompt identities are derived from the active H3 Continuum sampler conditioning topology. Without that sampler, Writer cannot know whether `<Picture N>` belongs to Reference Images, First/Last keyframes, or nothing at all.
+
+**Fix**
+
+Add a supported **H3 Continuum Sampler V3.4–V3.7** to the current workflow. If several compatible samplers are present, select exactly one on the canvas before generating or refining.
+
+**Verify**
+
+Generation reaches the sequence planner only after Writer can inspect the intended sampler. Workflow-only references may remain absent from Prompt Writer/Qwen media as long as their H3 Continuum conditioning inputs are connected and their roles are described in the Creative Brief.
+
+## Continuum conditioning changed after generation
+
+**Symptom**
+
+Writer reports **Continuum conditioning changed** or the backend returns `CONTINUUM_REFERENCE_SOURCE_DRIFT` when refining or applying a saved sequence.
+
+**Cause**
+
+New Continuum sequences snapshot the normalized H3 Continuum downstream conditioning inventory used during planning. The active sampler now resolves one or more Reference Image, First Frame, Last Frame, Video Reference, or Driving Audio inputs to different observable workflow sources even though public tags such as `<Picture 1>` may still look unchanged.
+
+**Fix**
+
+Restore the original H3 Continuum conditioning wiring or regenerate the sequence against the current workflow. Writer does not silently reinterpret a saved sequence plan against a different reference/keyframe source.
+
+**Verify**
+
+Refine and **Apply to Continuum** proceed without a source-drift warning. Legacy saved sequences without an inventory snapshot remain readable and acquire the active snapshot after their next successful chunk refinement.
+
+## Continuum chunk returned a standalone H3 wrapper
+
+**Symptom**
+
+A prompt model tries to return `integrated_multimodal_description:`, `subject_definitions:`, `[Shot 1]`, a standalone keyframe-alignment line, a Markdown fence, or repeats the shared sequence preamble inside one Timeline chunk.
+
+**Cause**
+
+The model followed a standalone H3 authoring habit instead of the dedicated Continuum chunk-body contract. Continuum already owns the outer Timeline boundaries and prepends the shared preamble to every resolved chunk.
+
+**Fix**
+
+Writer treats these shapes as objective chunk-format failures and makes one narrow Continuum-only text correction. The correction removes the wrapper or repeated preamble while preserving supported action, state, camera, dialogue, sound, and valid scoped reference tags.
+
+**Verify**
+
+The stored chunk body contains only local Continuum prompt prose. It has no shared-preamble duplicate, standalone H3 field labels, `[Shot N]` wrapper, or nested Timeline header.
+
+## Continuum reference declaration failure
+
+**Symptom**
+
+Writer reports `CONTINUUM_REFERENCE_IDENTITY_DRIFT` for an undeclared public reference, or `CONTINUUM_REFERENCE_SCOPE_DRIFT` when a declared reference is used outside its valid chunk scope.
+
+**Cause**
+
+The Creative Brief, semantic plan, or generated chunk uses a public reference identity that the selected H3 Continuum sampler does not expose in that scope. With active **Reference Images**, those inputs own compact public `<Picture 1..N>` numbering and First/Last Frame stay untagged. Without Reference Images, active First/Last Frame keyframes own the compact Picture identities. **Video Reference** is `<Video 1>`; **Reference Audio** on V3.5+ is persistent `<Audio 1>`; **Driving Audio** has no `<Audio N>` tag. In multi-chunk keyframe runs, the opening Picture tag is valid only in Chunk 1 and the final Picture tag only in the final chunk. Prompt Writer uploads do not automatically inherit any downstream identity.
+
+**Fix**
+
+Select the intended H3 Continuum sampler and inspect its active conditioning inputs. With Reference Images, use their compact active-connection numbering; for example, physical Reference Image 2 and 5 become public `<Picture 1>` and `<Picture 2>`. Without Reference Images, use the temporal keyframe numbering derived from the connected First/Last inputs. Use `<Video 1>` only when Video Reference is connected. Use `<Audio 1>` only for connected Reference Audio on V3.5+; never create an `<Audio 1>` tag merely because Driving Audio is connected. Keep opening/final keyframe tags out of middle chunks and the shared preamble.
+
+**Verify**
+
+Generation reaches the planner and chunk writer without `CONTINUUM_REFERENCE_IDENTITY_DRIFT` or `CONTINUUM_REFERENCE_SCOPE_DRIFT`. Every public tag belongs to the selected downstream inventory and appears only in chunks where that conditioning identity is valid.
 
 ## API authentication, rate limit, or truncated response
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -17,6 +17,65 @@ Use the fullscreen button in the Writer header when you want the workspace to fi
 
 ![Reference mode with a generated prompt](assets/v0.3/reference-workspace.png)
 
+## H3 Continuum sequences
+
+**H3 Continuum** is an output target for the five H3 Video modes. It is not a sixth mode. Choose the underlying T2VA, I2VA, FL2VA, L2VA, or Reference mode first, then select **H3 Continuum** under **Output target**.
+
+Set **Chunks** from 1 to 16 and **Seconds per chunk** from 4 to 30; 5 to 15 seconds remains the upstream recommended and validated range. Writer shows their total duration but sends the native per-chunk duration to H3. For example, 8 chunks at 6 seconds is a 48-second sequence.
+
+Sequence generation is staged:
+
+1. Writer creates and validates one semantic continuity plan for the complete sequence. The model writes sequence-wide H3 prose in `global.sequence_preamble`, while Writer owns chunk count, exact time boundaries, and public downstream reference identities.
+2. Writer generates each chunk-local H3 prompt in order. Continuous chunks receive the previous terminal state and previous chunk prompt; an intentional cut or reset is allowed only when the plan marks an explicit `intentional_break`. Chunk bodies use Continuum-native prose rather than standalone I2VA/FL2VA/L2VA/Reference wrappers. The dedicated authoring contract keeps the format-safe H3 rules: grounded visible/audible progression, natural camera motion, stable speaker IDs, exact `<d>[Language] ...</d>` dialogue, verbatim visible text, requested-only music, and exclusive reference-role transfer. Absolute sequence timing belongs to the outer Timeline headers.
+3. Writer serializes one canonical Continuum Timeline. Persistent H3 prose appears before the first section header, then every chunk body appears below its exact `[start-end]` header.
+
+For three 5-second chunks, the shape is:
+
+```text
+Persistent sequence-wide H3 identity, reference, wardrobe, environment, style, camera, lighting, audio, and exclusion rules.
+
+[0-5s]
+Chunk-local H3 prompt for the first span.
+
+[5-10s]
+Chunk-local H3 prompt continuing from the first span.
+
+[10-15s]
+Chunk-local H3 prompt continuing from the second span.
+```
+
+The header must be on its own line. Writer computes integer and fractional boundaries deterministically from **Seconds per chunk**; a 6.5-second sequence therefore uses `[0-6.5s]`, `[6.5-13s]`, `[13-19.5s]`, and so on. Writer does not depend on Continuum's parser fallback to reinterpret malformed text.
+
+The plan keeps subject identity, wardrobe, environment, camera axis, lighting, sound, dialogue, visible text, constraints, and reference roles stable. Prompt models are probabilistic, so review the sequence; Writer validates structure and stable identifiers but cannot guarantee perfect visual continuity from the video model.
+
+Install [ComfyUI H3 Continuum](https://github.com/ukr8b3g-cmyk/ComfyUI-H3-Continuum) and use a supported **H3 Continuum Sampler V3.4–V3.7** (V3.7 is the current upstream release). Connect a **Text (Multiline)** node to the sampler's **Sequence Prompt** input. **Apply to Continuum** requires **Prompt Format = Timeline** and writes the canonical sequence into that connected text widget. If more than one compatible sampler exists, select exactly one on the canvas first. If Prompt Format, chunk count, or chunk duration differs, Writer shows every mismatch and offers an explicit **Sync settings & apply** action. That action changes only those sampler settings and the connected text value; it does not add or rewire nodes.
+
+### Continuum references and keyframes
+
+Before a Continuum generation or refinement request, Writer requires a compatible H3 Continuum V3.4–V3.7 sampler in the current workflow, inspects its active conditioning inputs, and derives the same public identities that H3 Continuum presents to MiniMax. If no compatible sampler exists, Writer stops before contacting the prompt model; it does not invent an empty reference topology. The backend enforces the same contract, so direct Continuum API requests must include the downstream inventory explicitly; an empty inventory means the inspected sampler genuinely has no active conditioning inputs.
+
+When one or more **Reference Image** sockets are active, those Reference Images own the public Picture namespace in active connection order, compacted to `<Picture 1>` through `<Picture N>`. Gaps in physical socket numbers do not create gaps in public numbering. In these hybrid runs, connected **First Frame** and **Last Frame** remain temporal keyframes and do not receive separate public Picture tags.
+
+Writer also checks the selected mode against the sampler's conditioning topology before generation, refinement, and graph handoff. T2VA requires no First/Last keyframe and no active Reference Image input; Reference Images without temporal keyframes are H3 Continuum Reference conditioning, not T2VA. I2VA requires First Frame only, FL2VA requires both First and Last Frame, and L2VA requires Last Frame only. Reference mode remains hybrid-capable: Reference Images can coexist with either or both keyframes. Reference Images augment I2VA/FL2VA/L2VA rather than changing those keyframe modes.
+
+When no Reference Image socket is active, connected temporal keyframes own the compact Picture namespace instead: **First Frame** is `<Picture 1>`; **Last Frame** is the next active Picture identity, so FL2VA uses `<Picture 1>` for the opening and `<Picture 2>` for the ending, while L2VA uses `<Picture 1>` for its sole final keyframe. In a multi-chunk sequence, an opening-keyframe tag is valid only in Chunk 1 and a final-keyframe tag is valid only in the final chunk; neither belongs in the shared preamble. Persistent Reference Image tags remain valid across chunks.
+
+**Video Reference** owns the persistent public tag `<Video 1>`. On V3.5 and newer, **Reference Audio** owns persistent `<Audio 1>` and can be used in the shared preamble and every chunk. **Driving Audio** is a different contract: it is persistent downstream conditioning and owns no `<Audio N>` prompt tag. V3.7's optional **Still Image Guide** also owns no public prompt tag. Writer validates these scopes in the semantic plan, generated chunk, and chunk-refinement paths.
+
+The downstream workflow inventory and the prompt model's visible media are separate contracts. A connected Reference Image can be declared as `<Picture 1>` even when its pixels were never uploaded to Prompt Writer or Qwen. In that case Writer tells the planner that the reference exists and is not model-visible, and the model must not invent its appearance. State the intended role in the Creative Brief, for example `Use <Picture 1> for the subject identity`.
+
+Prompt Writer media is never assumed to be the same downstream reference merely because both would otherwise be called `<Picture 1>`. Unverified uploaded media is labeled as analysis media for the prompt model instead of silently taking a downstream public identity.
+
+When [Image Conveyor](https://github.com/xmarre/ComfyUI-Image-Conveyor) feeds the selected Continuum sampler, Writer resolves Conveyor's effective output contract rather than treating every saved wire as active. In **Reference + H3 Continuum**, the Media panel contains an **Active workflow images** section. **Add active workflow refs** copies each stable, active Conveyor Reference Shelf image (and direct Load Image source) into the temporary Prompt Writer media session, marks that downstream item `visible_to_model`, and binds the copied asset to the same public `<Picture N>`/conditioning role. This is the control to use when the prompt model must actually inspect the reference pixels instead of merely knowing that the downstream slot exists. In **Persistent references** mode, only populated Reference Shelf slots whose matching output switch is enabled can become Reference Images; disabled or empty shelf outputs are excluded even if their wires remain visible. The independent Main and Last Frame switches likewise determine whether Conveyor-backed temporal keyframes are active, including through a single-image transform chain or bypass node. Persistent shelf Reference Images receive an opaque local source fingerprint in the saved inventory, so replacing a shelf image is detected as source drift even when the graph wire does not change; filenames are not stored in that fingerprint. Sequences saved before this fingerprint existed are accepted as legacy-unknown on their first compatible use and adopt the current fingerprint after a successful refinement, avoiding an upgrade-only false drift. In **Queue execution group** mode, Writer follows **Images per execution** exactly: `image` is group image 1, `ref_image_1` through `ref_image_8` expose subsequent group members, and `last_frame` aliases group image 2. Queue members remain intentionally dynamic and are not content-fingerprinted. Because their concrete file is selected at queue time, queue-group and other queue-driven outputs are shown as dynamic and are not falsely imported as stable Prompt Writer media. For the reviewed `ImageScaleToTotalPixelsX` implementation from **Scale Image to Total Pixels Adv**, Writer can materialize a stable Conveyor Reference Shelf or direct Load Image source through static `megapixels`, `multiple_of`, `stretch/crop/pad`, and **Lanczos** settings. The transform parameters are part of the saved source fingerprint, so changing 0.70→0.80 MP, the multiple, resize mode, or source image produces **Update needed**. Any connected runtime override for width, height, megapixels, multiple-of, resize mode, or interpolation, plus non-Lanczos interpolation, animated files, further arbitrary processing chains, and other transforms stay unavailable rather than pretending a stale widget or pre-transform source matches H3. After a transformed reference is added, its workflow row previews the post-transform Writer asset that the prompt model actually sees. **Don't consume** changes queue reuse, not the public conditioning topology.
+
+A text-only Direct GGUF can therefore write I2VA, FL2VA, L2VA, or Reference **Continuum** prompts when all visual conditioning is workflow-only. If you attach Prompt Writer images or video for the model to inspect during initial generation, a matching vision projector is still required. Chunk refinement does not re-upload those media, so a saved Continuum sequence can remain in its original mode and be refined with a text-only Direct model even when the earlier analysis media is still attached.
+
+For a local change, open **Refine**, select one Timeline section, and describe the revision. Writer regenerates only that chunk body and preserves the shared preamble and every other body byte-for-byte. H3 Continuum Run Storage hashes each **resolved prompt** after the Timeline preamble has been prepended. A local Chunk 3 edit therefore preserves earlier resolved hashes; changing the shared preamble changes every resolved hash. Writer treats shared-preamble changes as sequence-wide changes and requires regeneration rather than disguising them as a chunk-local edit.
+
+Legacy Prompt Writer drafts using strict, contiguous `[Chunk N]` sections can be migrated into Timeline form. New production output and graph handoff use Timeline only.
+
+The target, settings, validated plan, shared preamble, chunk bodies, resolved hashes, manual draft, and normalized downstream H3 Continuum conditioning inventory are saved with the current mode. On later refinement or graph handoff, Writer compares that snapshot with the active sampler and stops if an observable reference/keyframe source changed while keeping the same public tag. Legacy drafts without a snapshot remain readable and adopt the active inventory after a successful chunk refinement. API credentials are not part of that saved state.
+
 ## Modes
 
 | Mode | Input | How the media is used |
@@ -159,6 +218,8 @@ Writer saves stable preferences in the browser used to open ComfyUI:
 It never saves API keys. If a saved model no longer exists, discovery falls back without treating the missing model as a fatal error.
 
 Every H3 mode keeps its own Creative Brief and editable prompt draft across a page reload. Music 3 separately keeps its Music Brief, Lyrics, and edited caption. Uploaded media is session content and is not restored after reload.
+
+Continuum drafts additionally keep their generation target, chunk settings, validated continuity plan, and individual prompts. This structural state is used for chunk-local refinement; it contains no provider secret or API key.
 
 In **Settings > Prompt behavior**, select **Restore default drafts**. The button changes to **Click again to confirm** for five seconds. Select it again to delete every saved mode draft. The current mode immediately returns to its current built-in Creative Brief and prompt; the other modes use their current built-in defaults when opened. This includes Reference. Media, provider settings, custom system prompts, and API credentials are not changed.
 

--- a/standalone/tests/test_host.py
+++ b/standalone/tests/test_host.py
@@ -151,8 +151,10 @@ class ManagedGGUFTest(unittest.TestCase):
             other_model.touch()
             projector.touch()
 
+            model_paths = {model.resolve(), other_model.resolve()}
+
             def reader(path: Path) -> dict[str, object]:
-                if path in {model, other_model}:
+                if path.resolve() in model_paths:
                     return {
                         "architecture": "qwen35",
                         "name": "Qwen3.8-27B",

--- a/tests/frontend_regressions.mjs
+++ b/tests/frontend_regressions.mjs
@@ -20,6 +20,23 @@ const {
   unloadWriterModels,
   writerResidencyTargets,
 } = await import(`data:text/javascript;base64,${vramHandoffEncoded}`);
+const continuumSource = await readFile(new URL("../web/continuum.js", import.meta.url), "utf8");
+const continuumEncoded = Buffer.from(continuumSource).toString("base64");
+const {
+  applySequenceToContinuum,
+  chooseContinuumSampler,
+  connectedSequenceTextSource,
+  discoverContinuumReferenceInventory,
+  normalizeContinuumSettings,
+  parseContinuumTimeline,
+  sequenceStateFromResult,
+  sameContinuumReferenceInventory,
+  serializeContinuumPrompts,
+  timelineBoundary,
+  updateContinuumDraftFromEditor,
+  validateContinuumModeTopology,
+  validateContinuumReferenceScope,
+} = await import(`data:text/javascript;base64,${continuumEncoded}`);
 const stateSource = await readFile(new URL("../web/studio_state.js", import.meta.url), "utf8");
 const stateEncoded = Buffer.from(stateSource).toString("base64");
 const {
@@ -79,6 +96,739 @@ function memoryStorage(initial = {}) {
     entries: () => Object.fromEntries(values),
   };
 }
+
+function continuumGraph({ samplerCount = 1, samplerType = "H3ContinuumSamplerV34", connected = true, referenceInputs = [] } = {}) {
+  const links = {};
+  const nodes = [];
+  for (let offset = 0; offset < samplerCount; offset += 1) {
+    const samplerInputs = [
+      { name: "sequence_prompt", type: "STRING", link: connected && offset === 0 ? 10 : null },
+      { name: "first_frame", type: "IMAGE", link: null },
+      { name: "last_frame", type: "IMAGE", link: null },
+      ...Array.from({ length: 8 }, (_, index) => ({ name: `reference_image_${index + 1}`, type: "IMAGE", link: null })),
+      { name: "reference_video_1", type: "IMAGE", link: null },
+      { name: "reference_audio_1", type: "AUDIO", link: null },
+      { name: "driving_audio", type: "AUDIO", link: null },
+    ];
+    const sampler = {
+      id: 100 + offset,
+      type: samplerType,
+      title: `Sampler ${offset + 1}`,
+      inputs: samplerInputs,
+      widgets: [
+        { name: "prompt_mode", value: "Timeline" },
+        { name: "chunks", value: 3 },
+        { name: "chunk_seconds", value: 5 },
+      ],
+    };
+    nodes.push(sampler);
+  }
+  const textWidget = { name: "value", value: "old", callbackCalls: 0 };
+  textWidget.callback = () => { textWidget.callbackCalls += 1; };
+  const text = {
+    id: 1,
+    type: "PrimitiveStringMultiline",
+    inputs: [],
+    outputs: [{ name: "STRING", type: "STRING", links: [10] }],
+    widgets: [textWidget],
+    widgetChanges: [],
+    onWidgetChanged(...args) { this.widgetChanges.push(args); },
+  };
+  if (connected) {
+    nodes.push(text);
+    links[10] = { origin_id: 1, origin_slot: 0, target_id: 100, target_slot: 0 };
+  }
+
+  for (const spec of referenceInputs) {
+    const sampler = nodes.find((node) => node.id === (spec.samplerId ?? 100));
+    const inputIndex = sampler.inputs.findIndex((input) => input.name === spec.input);
+    if (inputIndex < 0) throw new Error(`Unknown test sampler input ${spec.input}`);
+    const linkId = 1000 + Object.keys(links).length;
+    const source = {
+      id: spec.sourceId,
+      type: spec.sourceType ?? "LoadImage",
+      mode: spec.mode ?? 0,
+      inputs: [],
+      outputs: [{ name: spec.outputName ?? "IMAGE", type: spec.outputType ?? "IMAGE", links: [linkId] }],
+      widgets: [],
+    };
+    sampler.inputs[inputIndex].link = linkId;
+    nodes.push(source);
+    links[linkId] = { origin_id: source.id, origin_slot: 0, target_id: sampler.id, target_slot: inputIndex };
+  }
+
+  const graph = {
+    _nodes: nodes,
+    links,
+    dirtyCalls: 0,
+    changeCalls: 0,
+    getNodeById(id) { return this._nodes.find((node) => node.id === id); },
+    setDirtyCanvas() { this.dirtyCalls += 1; },
+    change() { this.changeCalls += 1; },
+  };
+  nodes.forEach((node) => { node.graph = graph; });
+  const canvas = { selected_nodes: {}, dirtyCalls: 0, setDirty() { this.dirtyCalls += 1; } };
+  return { app: { graph, canvas }, graph, samplers: nodes.filter((node) => node.type === samplerType), text, textWidget };
+}
+
+test("Continuum Timeline serialization is canonical for integer and fractional durations", () => {
+  const prompts = ["First prompt.\nLine two.", "Second prompt.", "Third prompt."];
+  const serialized = serializeContinuumPrompts(prompts, {
+    preamble: "Persistent identity and film treatment.",
+    chunkSeconds: 5,
+  });
+  assert.equal(
+    serialized,
+    "Persistent identity and film treatment.\n\n[0-5s]\nFirst prompt.\nLine two.\n\n[5-10s]\nSecond prompt.\n\n[10-15s]\nThird prompt.",
+  );
+  assert.deepEqual(parseContinuumTimeline(serialized, { expectedChunks: 3, chunkSeconds: 5 }), {
+    preamble: "Persistent identity and film treatment.",
+    prompts,
+  });
+  assert.equal(timelineBoundary(6.5, 0), "0");
+  assert.equal(timelineBoundary(6.5, 1), "6.5");
+  assert.equal(timelineBoundary(6.5, 2), "13");
+  assert.equal(timelineBoundary(6.5, 3), "19.5");
+  assert.throws(
+    () => parseContinuumTimeline("[0-5s] inline", { expectedChunks: 1, chunkSeconds: 5 }),
+    /No canonical/,
+  );
+  assert.deepEqual(normalizeContinuumSettings({ chunks: 16, chunk_seconds: 30 }), {
+    schema_version: 2,
+    chunks: 16,
+    chunk_seconds: 30,
+    total_seconds: 480,
+  });
+});
+
+test("Continuum accepts the current H3 Continuum V3.4 through V3.7 sampler family", () => {
+  for (const samplerType of [
+    "H3ContinuumSamplerV34",
+    "H3ContinuumSamplerV35",
+    "H3ContinuumSamplerV36",
+    "H3ContinuumSamplerV37",
+  ]) {
+    const { app, samplers } = continuumGraph({ samplerType });
+    const choice = chooseContinuumSampler(app);
+    assert.equal(choice.status, "selected");
+    assert.equal(choice.sampler, samplers[0]);
+  }
+});
+
+test("Continuum structural drafts migrate strict legacy chunks and preserve malformed manual text", () => {
+  const legacy = {
+    schema_version: 1,
+    settings: { chunks: 2, chunk_seconds: 5 },
+    plan: { schema_version: 1 },
+    prompts: ["One", "Two"],
+  };
+  const migrated = updateContinuumDraftFromEditor(legacy, "[Chunk 1]\nChanged one\n\n[Chunk 2]\nTwo");
+  assert.equal(migrated.schema_version, 2);
+  assert.deepEqual(migrated.prompts, ["Changed one", "Two"]);
+  assert.equal(migrated.preamble, "");
+  assert.equal(migrated.raw_prompt, null);
+
+  const valid = updateContinuumDraftFromEditor(
+    { ...migrated, plan: { schema_version: 2 } },
+    "Global.\n\n[0-5s]\nChanged one\n\n[5-10s]\nTwo",
+  );
+  assert.equal(valid.preamble, "Global.");
+  const invalid = updateContinuumDraftFromEditor(valid, "[0-5s]\nChanged one");
+  assert.equal(invalid.raw_prompt, "[0-5s]\nChanged one");
+  assert.deepEqual(invalid.prompts, ["Changed one", "Two"]);
+
+  const v2LegacyText = updateContinuumDraftFromEditor(
+    {
+      ...valid,
+      schema_version: 2,
+      migrated_from_schema_version: undefined,
+      preamble: "Global.",
+      prompts: ["Changed one", "Two"],
+    },
+    "[Chunk 1]\nChanged again\n\n[Chunk 2]\nTwo",
+  );
+  assert.equal(v2LegacyText.preamble, "Global.");
+  assert.deepEqual(v2LegacyText.prompts, ["Changed one", "Two"]);
+  assert.match(v2LegacyText.raw_prompt, /^\[Chunk 1\]/);
+});
+
+test("Continuum result state verifies canonical Timeline text against structural chunks", () => {
+  const result = {
+    prompt: "Global.\n\n[0-5s]\nOne\n\n[5-10s]\nTwo",
+    sequence: {
+      schema_version: 2,
+      settings: { schema_version: 2, chunks: 2, chunk_seconds: 5, total_seconds: 10 },
+      plan: { schema_version: 2 },
+      preamble: "Global.",
+      chunks: [{ index: 1, body: "One" }, { index: 2, body: "Two" }],
+    },
+  };
+  assert.deepEqual(sequenceStateFromResult(result).prompts, ["One", "Two"]);
+  result.prompt = "Global.\n\n[0-5s]\nOne\n\n[5-10s]\nChanged";
+  assert.throws(() => sequenceStateFromResult(result), /canonical Timeline text does not match/);
+});
+
+test("Continuum sequence state preserves downstream conditioning inventory snapshots", () => {
+  const inventory = {
+    schema_version: 1,
+    items: [{
+      role: "reference_image",
+      kind: "image",
+      source: "workflow",
+      visible_to_model: false,
+      tag: "<Picture 1>",
+      input_name: "reference_image_1",
+      source_node_id: 41,
+      source_node_class: "LoadImage",
+      source_output_name: "IMAGE",
+      source_slot: 0,
+    }],
+  };
+  const result = {
+    prompt: "Global.\n\n[0-5s]\nOne\n\n[5-10s]\nTwo",
+    sequence: {
+      schema_version: 2,
+      settings: { chunks: 2, chunk_seconds: 5 },
+      plan: { schema_version: 2 },
+      preamble: "Global.",
+      downstream_reference_inventory: inventory,
+      chunks: [{ index: 1, body: "One" }, { index: 2, body: "Two" }],
+    },
+  };
+  assert.deepEqual(
+    sequenceStateFromResult(result).downstream_reference_inventory,
+    inventory,
+  );
+});
+
+test("Continuum inventory identity compares semantic fields independently of object key order", () => {
+  const left = {
+    schema_version: 1,
+    items: [{
+      role: "reference_image",
+      kind: "image",
+      source: "workflow",
+      visible_to_model: false,
+      tag: "<Picture 1>",
+      source_node_id: 41,
+      source_node_class: "LoadImage",
+      source_output_name: "IMAGE",
+      source_slot: 0,
+    }],
+  };
+  const right = {
+    items: [{
+      source_slot: 0,
+      source_output_name: "IMAGE",
+      source_node_class: "LoadImage",
+      source_node_id: 41,
+      tag: "<Picture 1>",
+      visible_to_model: false,
+      source: "workflow",
+      kind: "image",
+      role: "reference_image",
+    }],
+    schema_version: 1,
+  };
+  assert.equal(sameContinuumReferenceInventory(left, right), true);
+  right.items[0].source_node_id = 99;
+  assert.equal(sameContinuumReferenceInventory(left, right), false);
+});
+
+test("Continuum inventory identity treats a missing saved source fingerprint as legacy unknown but enforces it once saved", () => {
+  const legacy = {
+    schema_version: 1,
+    items: [{
+      role: "reference_image",
+      kind: "image",
+      source: "workflow",
+      visible_to_model: false,
+      tag: "<Picture 1>",
+      source_node_id: 41,
+      source_node_class: "ImageConveyor",
+      source_output_name: "ref_image_1",
+      source_slot: 6,
+    }],
+  };
+  const active = structuredClone(legacy);
+  active.items[0].source_identity = "image-conveyor-ref-v1:1111111111111111";
+
+  assert.equal(sameContinuumReferenceInventory(legacy, active), true);
+
+  const saved = structuredClone(active);
+  active.items[0].source_identity = "image-conveyor-ref-v1:2222222222222222";
+  assert.equal(sameContinuumReferenceInventory(saved, active), false);
+
+  const activeWithoutFingerprint = structuredClone(legacy);
+  assert.equal(sameContinuumReferenceInventory(saved, activeWithoutFingerprint), false);
+});
+
+test("Continuum workflow discovery failures are surfaced before generate, refine, and apply", () => {
+  const message = 'showToast("Continuum conditioning could not be read", error.message);';
+  assert.equal(mainSource.split(message).length - 1, 3);
+  assert.match(
+    mainSource,
+    /async function startGenerationPreview\(\)[\s\S]*?try \{[\s\S]*?discoverContinuumReferenceInventory\(app, target\.sampler\)[\s\S]*?catch \(error\) \{[\s\S]*?Continuum conditioning could not be read/,
+  );
+  assert.match(
+    mainSource,
+    /async function submitRefinement\(\)[\s\S]*?try \{[\s\S]*?discoverContinuumReferenceInventory\(app, target\.sampler\)[\s\S]*?catch \(error\) \{[\s\S]*?Continuum conditioning could not be read/,
+  );
+  assert.match(
+    mainSource,
+    /async function applyCurrentSequence\(syncSettings = false\)[\s\S]*?try \{[\s\S]*?applySequenceToContinuum\(app, choice\.sampler[\s\S]*?catch \(error\) \{[\s\S]*?Continuum conditioning could not be read/,
+  );
+});
+
+test("Continuum graph handoff writes Timeline and treats Prompt Format as an explicit setting", () => {
+  const { app, samplers, textWidget, graph } = continuumGraph();
+  const choice = chooseContinuumSampler(app);
+  assert.equal(choice.status, "selected");
+  assert.equal(choice.sampler, samplers[0]);
+  assert.equal(connectedSequenceTextSource(graph, samplers[0]).status, "connected");
+  const state = {
+    settings: { chunks: 3, chunk_seconds: 5 },
+    preamble: "Global.",
+    prompts: ["One", "Two", "Three"],
+  };
+  let result = applySequenceToContinuum(app, samplers[0], state);
+  assert.equal(result.status, "applied");
+  assert.equal(textWidget.value, "Global.\n\n[0-5s]\nOne\n\n[5-10s]\nTwo\n\n[10-15s]\nThree");
+  assert.equal(textWidget.callbackCalls, 1);
+  assert.equal(graph.changeCalls, 1);
+
+  samplers[0].widgets.find((entry) => entry.name === "prompt_mode").value = "Auto";
+  result = applySequenceToContinuum(app, samplers[0], state);
+  assert.equal(result.status, "mismatch");
+  assert.deepEqual(result.mismatches.map((item) => item.field), ["prompt_mode"]);
+  result = applySequenceToContinuum(app, samplers[0], state, { syncSettings: true });
+  assert.equal(result.status, "applied");
+  assert.equal(samplers[0].widgets.find((entry) => entry.name === "prompt_mode").value, "Timeline");
+});
+
+test("Continuum graph discovery compacts Reference Image gaps without counting keyframes", () => {
+  const { app, samplers } = continuumGraph({
+    referenceInputs: [
+      { input: "first_frame", sourceId: 20 },
+      { input: "last_frame", sourceId: 21 },
+      { input: "reference_image_2", sourceId: 22 },
+      { input: "reference_image_5", sourceId: 23 },
+      { input: "reference_video_1", sourceId: 24, outputType: "IMAGE", outputName: "IMAGE" },
+      { input: "driving_audio", sourceId: 25, outputType: "AUDIO", outputName: "AUDIO" },
+    ],
+  });
+  const inventory = discoverContinuumReferenceInventory(app, samplers[0]);
+  assert.deepEqual(
+    inventory.items.filter((item) => item.tag).map((item) => [item.input_name, item.tag]),
+    [
+      ["reference_image_2", "<Picture 1>"],
+      ["reference_image_5", "<Picture 2>"],
+      ["reference_video_1", "<Video 1>"],
+    ],
+  );
+  assert.deepEqual(
+    inventory.items.filter((item) => !item.tag).map((item) => item.role),
+    ["first_frame", "last_frame", "driving_audio"],
+  );
+  assert.ok(inventory.items.every((item) => item.visible_to_model === false));
+});
+
+test("Continuum graph discovery gives keyframes Picture identities when no Reference Images exist", () => {
+  const { app, samplers } = continuumGraph({
+    referenceInputs: [
+      { input: "first_frame", sourceId: 26 },
+      { input: "last_frame", sourceId: 27 },
+      { input: "reference_video_1", sourceId: 28, outputType: "IMAGE", outputName: "IMAGE" },
+      { input: "driving_audio", sourceId: 29, outputType: "AUDIO", outputName: "AUDIO" },
+    ],
+  });
+  const inventory = discoverContinuumReferenceInventory(app, samplers[0]);
+  assert.deepEqual(
+    inventory.items.map((item) => [item.role, item.tag ?? null]),
+    [
+      ["first_frame", "<Picture 1>"],
+      ["last_frame", "<Picture 2>"],
+      ["video_reference", "<Video 1>"],
+      ["driving_audio", null],
+    ],
+  );
+});
+
+test("Continuum discovery exposes Reference Audio as persistent <Audio 1> and leaves Driving Audio untagged", () => {
+  const { app, samplers } = continuumGraph({
+    samplerType: "H3ContinuumSamplerV37",
+    referenceInputs: [
+      { input: "reference_audio_1", sourceId: 71, sourceType: "LoadAudio", outputName: "AUDIO", outputType: "AUDIO" },
+      { input: "driving_audio", sourceId: 72, sourceType: "LoadAudio", outputName: "AUDIO", outputType: "AUDIO" },
+    ],
+  });
+  const inventory = discoverContinuumReferenceInventory(app, samplers[0]);
+  assert.deepEqual(
+    inventory.items.map((item) => [item.role, item.tag ?? null]),
+    [["reference_audio", "<Audio 1>"], ["driving_audio", null]],
+  );
+  const scope = validateContinuumReferenceScope(
+    inventory,
+    "Keep <Audio 1> persistent.",
+    ["Use <Audio 1>.", "Continue <Audio 1>.", "Finish <Audio 1>."],
+  );
+  assert.equal(scope.valid, true);
+  assert.deepEqual(scope.violations, []);
+  assert.deepEqual(scope.expected, ["<Audio 1>"]);
+  assert.deepEqual(scope.persistent, ["<Audio 1>"]);
+  assert.deepEqual(scope.chunk_scopes, [["<Audio 1>"], ["<Audio 1>"], ["<Audio 1>"]]);
+});
+
+test("Continuum temporal mode validation follows supported First/Last wiring while allowing reference augmentation", () => {
+  const inventory = (...items) => ({ schema_version: 1, items });
+  const first = { role: "first_frame" };
+  const last = { role: "last_frame" };
+  const reference = { role: "reference_image", tag: "<Picture 1>" };
+
+  assert.equal(validateContinuumModeTopology("T2VA", inventory()).valid, true);
+  assert.equal(validateContinuumModeTopology("T2VA", inventory(reference)).valid, false);
+  assert.equal(
+    validateContinuumModeTopology("T2VA", inventory(reference)).reason,
+    "reference_images_require_reference_mode",
+  );
+  assert.equal(validateContinuumModeTopology("T2VA", inventory(first)).valid, false);
+
+  assert.equal(validateContinuumModeTopology("I2VA", inventory(first)).valid, true);
+  assert.equal(validateContinuumModeTopology("I2VA", inventory(reference, first)).valid, true);
+  assert.equal(validateContinuumModeTopology("I2VA", inventory(first, last)).valid, false);
+
+  assert.equal(validateContinuumModeTopology("FL2VA", inventory(first, last)).valid, true);
+  assert.equal(validateContinuumModeTopology("FL2VA", inventory(reference, first, last)).valid, true);
+  assert.equal(validateContinuumModeTopology("FL2VA", inventory(first)).valid, false);
+
+  assert.equal(validateContinuumModeTopology("L2VA", inventory(last)).valid, true);
+  assert.equal(validateContinuumModeTopology("L2VA", inventory(reference, last)).valid, true);
+  assert.equal(validateContinuumModeTopology("L2VA", inventory(first, last)).valid, false);
+
+  assert.equal(validateContinuumModeTopology("Reference", inventory(reference)).valid, true);
+  assert.equal(validateContinuumModeTopology("Reference", inventory(reference, first, last)).valid, true);
+});
+
+test("Continuum reference scope validator enforces keyframe endpoints and persistent references", () => {
+  const keyframes = {
+    schema_version: 1,
+    items: [
+      { tag: "<Picture 1>", role: "first_frame" },
+      { tag: "<Picture 2>", role: "last_frame" },
+      { tag: "<Video 1>", role: "video_reference" },
+      { role: "driving_audio" },
+    ],
+  };
+  let result = validateContinuumReferenceScope(
+    keyframes,
+    "Persistent camera language.",
+    [
+      "Open from <Picture 1> with <Video 1> motion.",
+      "Continue with <Video 1> motion.",
+      "Land on <Picture 2> while retaining <Video 1> motion.",
+    ],
+  );
+  assert.equal(result.valid, true);
+  assert.deepEqual(result.chunk_scopes, [
+    ["<Picture 1>", "<Video 1>"],
+    ["<Video 1>"],
+    ["<Picture 2>", "<Video 1>"],
+  ]);
+
+  result = validateContinuumReferenceScope(
+    keyframes,
+    "Persistent camera language.",
+    ["Open from <Picture 1>.", "Reset to <Picture 1>.", "Land on <Picture 2>."],
+  );
+  assert.equal(result.valid, false);
+  assert.deepEqual(result.violations[0], {
+    kind: "scope",
+    scope: "chunk",
+    chunk_index: 2,
+    tags: ["<Picture 1>"],
+    allowed: ["<Video 1>"],
+  });
+
+  result = validateContinuumReferenceScope(
+    keyframes,
+    "Keep <Picture 2> fixed.",
+    ["Open.", "Continue.", "Finish."],
+  );
+  assert.equal(result.valid, false);
+  assert.equal(result.violations[0].scope, "global");
+  assert.deepEqual(result.violations[0].tags, ["<Picture 2>"]);
+
+  const hybrid = {
+    schema_version: 1,
+    items: [
+      { tag: "<Picture 1>", role: "reference_image" },
+      { role: "first_frame" },
+      { role: "last_frame" },
+      { tag: "<Video 1>", role: "video_reference" },
+    ],
+  };
+  result = validateContinuumReferenceScope(
+    hybrid,
+    "Keep <Picture 1> identity and <Video 1> motion stable.",
+    ["One.", "Use <Picture 1> and <Video 1>.", "Three."],
+  );
+  assert.equal(result.valid, true);
+});
+
+test("Continuum sync does not mutate sampler settings when Sequence Prompt has no editable source", () => {
+  const { app, samplers } = continuumGraph({ connected: false });
+  const sampler = samplers[0];
+  sampler.widgets.find((entry) => entry.name === "prompt_mode").value = "List";
+  sampler.widgets.find((entry) => entry.name === "chunks").value = 2;
+  sampler.widgets.find((entry) => entry.name === "chunk_seconds").value = 6;
+
+  const result = applySequenceToContinuum(app, sampler, {
+    settings: { chunks: 3, chunk_seconds: 5 },
+    preamble: "Global.",
+    prompts: ["One.", "Two.", "Three."],
+  }, { syncSettings: true });
+
+  assert.equal(result.status, "unconnected");
+  assert.equal(sampler.widgets.find((entry) => entry.name === "prompt_mode").value, "List");
+  assert.equal(sampler.widgets.find((entry) => entry.name === "chunks").value, 2);
+  assert.equal(sampler.widgets.find((entry) => entry.name === "chunk_seconds").value, 6);
+});
+
+test("Continuum apply rolls back sampler and text values when a widget callback throws", () => {
+  const { app, samplers, textWidget } = continuumGraph();
+  const sampler = samplers[0];
+  sampler.widgets.find((entry) => entry.name === "prompt_mode").value = "List";
+  sampler.widgets.find((entry) => entry.name === "chunks").value = 2;
+  const originalText = textWidget.value;
+  textWidget.callback = () => {
+    throw new Error("test callback failure");
+  };
+
+  const result = applySequenceToContinuum(app, sampler, {
+    settings: { chunks: 3, chunk_seconds: 5 },
+    preamble: "Global.",
+    prompts: ["One.", "Two.", "Three."],
+  }, { syncSettings: true });
+
+  assert.equal(result.status, "apply_failed");
+  assert.match(result.message, /test callback failure/);
+  assert.equal(sampler.widgets.find((entry) => entry.name === "prompt_mode").value, "List");
+  assert.equal(sampler.widgets.find((entry) => entry.name === "chunks").value, 2);
+  assert.equal(textWidget.value, originalText);
+});
+
+test("Continuum handoff rejects stale conditioning source inventory before mutation", () => {
+  const { app, samplers, textWidget } = continuumGraph({
+    referenceInputs: [{ input: "reference_image_1", sourceId: 41 }],
+  });
+  const active = discoverContinuumReferenceInventory(app, samplers[0]);
+  const saved = structuredClone(active);
+  saved.items[0].source_node_id = 99;
+  samplers[0].widgets.find((entry) => entry.name === "prompt_mode").value = "List";
+  samplers[0].widgets.find((entry) => entry.name === "chunks").value = 2;
+  const originalText = textWidget.value;
+
+  const result = applySequenceToContinuum(app, samplers[0], {
+    settings: { chunks: 3, chunk_seconds: 5 },
+    preamble: "Global.",
+    prompts: ["One.", "Two.", "Three."],
+    downstream_reference_inventory: saved,
+  }, { syncSettings: true, mode: "Reference" });
+
+  assert.equal(result.status, "source_inventory_mismatch");
+  assert.equal(samplers[0].widgets.find((entry) => entry.name === "prompt_mode").value, "List");
+  assert.equal(samplers[0].widgets.find((entry) => entry.name === "chunks").value, 2);
+  assert.equal(textWidget.value, originalText);
+});
+
+test("Continuum handoff rejects temporal mode mismatch before mutating sampler or text", () => {
+  const { app, samplers, textWidget } = continuumGraph({
+    referenceInputs: [
+      { input: "first_frame", sourceId: 26 },
+    ],
+  });
+  samplers[0].widgets.find((entry) => entry.name === "prompt_mode").value = "List";
+  samplers[0].widgets.find((entry) => entry.name === "chunks").value = 2;
+  const originalText = textWidget.value;
+  const result = applySequenceToContinuum(app, samplers[0], {
+    settings: { chunks: 3, chunk_seconds: 5 },
+    preamble: "Stable scene.",
+    prompts: ["One.", "Two.", "Three."],
+  }, { syncSettings: true, mode: "FL2VA" });
+  assert.equal(result.status, "mode_topology_mismatch");
+  assert.equal(result.mode_topology.actual.first_frame, true);
+  assert.equal(result.mode_topology.actual.last_frame, false);
+  assert.equal(samplers[0].widgets.find((entry) => entry.name === "prompt_mode").value, "List");
+  assert.equal(samplers[0].widgets.find((entry) => entry.name === "chunks").value, 2);
+  assert.equal(textWidget.value, originalText);
+});
+
+test("Continuum handoff rejects invalid manual reference scope before mutating sampler or text", () => {
+  const { app, samplers, textWidget } = continuumGraph({
+    referenceInputs: [
+      { input: "first_frame", sourceId: 26 },
+      { input: "last_frame", sourceId: 27 },
+    ],
+  });
+  samplers[0].widgets.find((entry) => entry.name === "prompt_mode").value = "List";
+  samplers[0].widgets.find((entry) => entry.name === "chunks").value = 2;
+  const originalText = textWidget.value;
+  const result = applySequenceToContinuum(app, samplers[0], {
+    settings: { chunks: 3, chunk_seconds: 5 },
+    preamble: "Stable scene.",
+    prompts: [
+      "Open from <Picture 1>.",
+      "Incorrectly reset to <Picture 1>.",
+      "Land on <Picture 2>.",
+    ],
+  }, { syncSettings: true });
+  assert.equal(result.status, "reference_mismatch");
+  assert.equal(result.violations[0].chunk_index, 2);
+  assert.equal(samplers[0].widgets.find((entry) => entry.name === "prompt_mode").value, "List");
+  assert.equal(samplers[0].widgets.find((entry) => entry.name === "chunks").value, 2);
+  assert.equal(textWidget.value, originalText);
+});
+
+test("Continuum graph discovery ignores Never-muted reference branches", () => {
+  const { app, samplers } = continuumGraph({
+    referenceInputs: [
+      { input: "reference_image_1", sourceId: 30, mode: 2 },
+      { input: "reference_image_4", sourceId: 31 },
+    ],
+  });
+  const inventory = discoverContinuumReferenceInventory(app, samplers[0]);
+  assert.deepEqual(inventory.items.map((item) => item.tag), ["<Picture 1>"]);
+  assert.equal(inventory.items[0].input_name, "reference_image_4");
+});
+
+test("Continuum graph discovery resolves a bypass node to its executable upstream image", () => {
+  const { app, graph, samplers } = continuumGraph({ connected: false });
+  const upstream = {
+    id: 40,
+    type: "LoadImage",
+    mode: 0,
+    inputs: [],
+    outputs: [{ name: "IMAGE", type: "IMAGE", links: [401] }],
+    widgets: [],
+  };
+  const bypass = {
+    id: 41,
+    type: "ImagePassThrough",
+    mode: 4,
+    inputs: [{ name: "image", type: "IMAGE", link: 401 }],
+    outputs: [{ name: "IMAGE", type: "IMAGE", links: [402] }],
+    widgets: [],
+  };
+  const refInput = samplers[0].inputs.find((input) => input.name === "reference_image_3");
+  refInput.link = 402;
+  graph._nodes.push(upstream, bypass);
+  upstream.graph = graph;
+  bypass.graph = graph;
+  graph.links[401] = { origin_id: 40, origin_slot: 0, target_id: 41, target_slot: 0 };
+  graph.links[402] = {
+    origin_id: 41,
+    origin_slot: 0,
+    target_id: samplers[0].id,
+    target_slot: samplers[0].inputs.indexOf(refInput),
+  };
+
+  const inventory = discoverContinuumReferenceInventory(app, samplers[0]);
+  assert.equal(inventory.items.length, 1);
+  assert.equal(inventory.items[0].tag, "<Picture 1>");
+  assert.equal(inventory.items[0].input_name, "reference_image_3");
+  assert.equal(inventory.items[0].source_node_id, 40);
+  assert.equal(inventory.items[0].source_node_class, "LoadImage");
+});
+
+test("Continuum graph discovery drops a bypass branch whose compatible upstream input is muted", () => {
+  const { app, graph, samplers } = continuumGraph({ connected: false });
+  const muted = {
+    id: 50,
+    type: "LoadImage",
+    mode: 2,
+    inputs: [],
+    outputs: [{ name: "IMAGE", type: "IMAGE", links: [501] }],
+    widgets: [],
+  };
+  const bypass = {
+    id: 51,
+    type: "ImagePassThrough",
+    mode: 4,
+    inputs: [{ name: "image", type: "IMAGE", link: 501 }],
+    outputs: [{ name: "IMAGE", type: "IMAGE", links: [502] }],
+    widgets: [],
+  };
+  const refInput = samplers[0].inputs.find((input) => input.name === "reference_image_1");
+  refInput.link = 502;
+  graph._nodes.push(muted, bypass);
+  muted.graph = graph;
+  bypass.graph = graph;
+  graph.links[501] = { origin_id: 50, origin_slot: 0, target_id: 51, target_slot: 0 };
+  graph.links[502] = {
+    origin_id: 51,
+    origin_slot: 0,
+    target_id: samplers[0].id,
+    target_slot: samplers[0].inputs.indexOf(refInput),
+  };
+
+  assert.deepEqual(discoverContinuumReferenceInventory(app, samplers[0]).items, []);
+});
+
+test("Continuum sequence text handoff follows a bypassed STRING pass-through to the editable source", () => {
+  const { app, graph, samplers, text, textWidget } = continuumGraph({ connected: false });
+  const passThrough = {
+    id: 61,
+    type: "StringPassThrough",
+    mode: 4,
+    inputs: [{ name: "text", type: "STRING", link: 610 }],
+    outputs: [{ name: "STRING", type: "STRING", links: [611] }],
+    widgets: [],
+  };
+  text.outputs[0].links = [610];
+  graph._nodes.push(text, passThrough);
+  text.graph = graph;
+  passThrough.graph = graph;
+  const sequenceInput = samplers[0].inputs.find((input) => input.name === "sequence_prompt");
+  sequenceInput.link = 611;
+  graph.links[610] = { origin_id: text.id, origin_slot: 0, target_id: passThrough.id, target_slot: 0 };
+  graph.links[611] = {
+    origin_id: passThrough.id,
+    origin_slot: 0,
+    target_id: samplers[0].id,
+    target_slot: samplers[0].inputs.indexOf(sequenceInput),
+  };
+
+  const source = connectedSequenceTextSource(graph, samplers[0]);
+  assert.equal(source.status, "connected");
+  assert.equal(source.node, text);
+  const result = applySequenceToContinuum(app, samplers[0], {
+    settings: { chunks: 3, chunk_seconds: 5 },
+    preamble: "Global.",
+    prompts: ["One", "Two", "Three"],
+  });
+  assert.equal(result.status, "applied");
+  assert.match(textWidget.value, /^Global\.\n\n\[0-5s\]/);
+});
+
+test("Continuum graph handoff never silently selects among multiple samplers", () => {
+  const { app, samplers } = continuumGraph({ samplerCount: 2, connected: false });
+  assert.equal(chooseContinuumSampler(app).status, "multiple");
+  app.canvas.selected_nodes = { [samplers[1].id]: samplers[1] };
+  assert.equal(chooseContinuumSampler(app).sampler, samplers[1]);
+});
+
+test("Continuum graph handoff reports all setting mismatches when Sequence Prompt is writable", () => {
+  assert.equal(chooseContinuumSampler({ graph: { _nodes: [] } }).status, "missing");
+  const { app, samplers } = continuumGraph();
+  samplers[0].widgets.find((entry) => entry.name === "prompt_mode").value = "List";
+  const result = applySequenceToContinuum(app, samplers[0], {
+    settings: { chunks: 4, chunk_seconds: 6 },
+    preamble: "Global.",
+    prompts: ["One", "Two", "Three", "Four"],
+  });
+  assert.equal(result.status, "mismatch");
+  assert.deepEqual(result.mismatches.map((item) => item.field), ["prompt_mode", "chunks", "chunk_seconds"]);
+});
 
 test("API responses preserve structured server errors", async () => {
   const response = {
@@ -426,6 +1176,9 @@ test("user preferences persist only stable non-secret settings", () => {
     musicLyricsUseBrief: false,
     fullscreen: true,
     vramHandoff: true,
+    generationTarget: "continuum",
+    continuumChunks: 8,
+    continuumChunkSeconds: 6.5,
     selectedModel: { id: "api::secret-connection::model", api_connection_id: "secret-connection" },
     apiProviderConfig: { api_key: "must-not-be-stored" },
     creativeBrief: "must-not-be-stored",
@@ -436,7 +1189,7 @@ test("user preferences persist only stable non-secret settings", () => {
   const serialized = storage.entries()[USER_PREFERENCES_STORAGE_KEY];
   assert.doesNotMatch(serialized, /secret|creativeBrief|keepModelLoaded|thinking|connection/);
   assert.deepEqual(loadUserPreferences(storage), {
-    version: 1,
+    version: 2,
     mode: "Reference",
     duration_seconds: 14,
     aspect_ratio: "9:16",
@@ -451,12 +1204,15 @@ test("user preferences persist only stable non-secret settings", () => {
     music_lyrics_use_brief: false,
     fullscreen: true,
     vram_handoff: true,
+    generation_target: "continuum",
+    continuum_chunks: 8,
+    continuum_chunk_seconds: 6.5,
   });
 });
 
 test("user preferences ignore corrupt or unknown versions and sanitize fields", () => {
   assert.equal(loadUserPreferences(memoryStorage({ [USER_PREFERENCES_STORAGE_KEY]: "{" })), null);
-  assert.equal(loadUserPreferences(memoryStorage({ [USER_PREFERENCES_STORAGE_KEY]: JSON.stringify({ version: 2 }) })), null);
+  assert.equal(loadUserPreferences(memoryStorage({ [USER_PREFERENCES_STORAGE_KEY]: JSON.stringify({ version: 3 }) })), null);
 
   const storage = memoryStorage({
     [USER_PREFERENCES_STORAGE_KEY]: JSON.stringify({
@@ -471,7 +1227,7 @@ test("user preferences ignore corrupt or unknown versions and sanitize fields", 
     }),
   });
   assert.deepEqual(loadUserPreferences(storage), {
-    version: 1,
+    version: 2,
     mode: "Reference",
     duration_seconds: 10,
     aspect_ratio: "16:9",
@@ -486,6 +1242,9 @@ test("user preferences ignore corrupt or unknown versions and sanitize fields", 
     music_lyrics_use_brief: true,
     fullscreen: false,
     vram_handoff: false,
+    generation_target: "single",
+    continuum_chunks: 3,
+    continuum_chunk_seconds: 5,
   });
 });
 
@@ -620,23 +1379,29 @@ test("all mode drafts persist independently across reloads", () => {
     Reference: { brief: "Reference brief", prompt: "Reference prompt" },
   });
   assert.deepEqual(loadModeDrafts(storage), {
-    T2VA: { brief: "Text brief", prompt: "Text prompt" },
-    I2VA: { brief: "Image brief", prompt: "Image prompt" },
-    Reference: { brief: "Reference brief", prompt: "Reference prompt" },
+    T2VA: { brief: "Text brief", prompt: "Text prompt", single_prompt: "Text prompt", generation_target: "single", continuum: null },
+    I2VA: { brief: "Image brief", prompt: "Image prompt", single_prompt: "Image prompt", generation_target: "single", continuum: null },
+    Reference: { brief: "Reference brief", prompt: "Reference prompt", single_prompt: "Reference prompt", generation_target: "single", continuum: null },
   });
   assert.match(storage.entries()[MODE_DRAFTS_STORAGE_KEY], /Reference brief|Reference prompt/);
-  assert.deepEqual(createStudioState({ sessionId: "drafts", storage }).modeDrafts.T2VA, { brief: "Text brief", prompt: "Text prompt" });
+  assert.deepEqual(createStudioState({ sessionId: "drafts", storage }).modeDrafts.T2VA, { brief: "Text brief", prompt: "Text prompt", single_prompt: "Text prompt", generation_target: "single", continuum: null });
 });
 
 test("clear prompts removes brief and generated output while preserving lyrics and extra draft state", () => {
   assert.deepEqual(clearPromptDraft({
     brief: "Keep the camera static.",
     prompt: "Generated prompt",
+    single_prompt: "Saved single prompt",
+    generation_target: "continuum",
+    continuum: { schema_version: 2 },
     lyrics: "[Verse]\nKeep these lyrics",
     marker: "preserved",
   }), {
     brief: "",
     prompt: "",
+    single_prompt: "",
+    generation_target: "continuum",
+    continuum: null,
     lyrics: "[Verse]\nKeep these lyrics",
     marker: "preserved",
   });
@@ -644,6 +1409,8 @@ test("clear prompts removes brief and generated output while preserving lyrics a
   assert.match(mainSource, /data-clear-prompts><strong>Clear prompts<\/strong><small>Keep media<\/small>/);
   assert.match(mainSource, /data-clear-all><strong>Clear all<\/strong><small>Media and prompts<\/small>/);
   assert.match(mainSource, /if \(!await clearCurrentMedia\(\{ notify: false \}\)\) return;/);
+  assert.match(mainSource, /async function clearCurrentMedia\(\{ notify = true \} = \{\}\)[\s\S]{0,320}studio\.workflowReferenceBindings = \{\};/);
+  assert.match(mainSource, /function clearCurrentPrompts[\s\S]{0,420}studio\.continuumSequence = draft\.continuum \|\| null;[\s\S]{0,700}studio\.modeDrafts\[studio\.mode\] = draft;/);
   assert.match(stylesSource, /\.h3ps-clear-control \{[^}]*display: inline-flex;[^}]*border-radius: 7px;/);
   assert.match(stylesSource, /\.h3ps-clear-menu \{[^}]*right: -20px;[^}]*width: max-content;[^}]*max-width: calc\(100vw - 24px\);/);
   assert.match(stylesSource, /\.h3ps-clear-menu button \{[^}]*display: grid;[^}]*min-height: 42px;/);
@@ -659,6 +1426,86 @@ test("custom contact sheet counts accept only whole values from 2 through 16", (
   assert.match(mainSource, /data-frame-custom-toggle>Custom<\/button><input[^>]+min="2" max="16"[^>]+data-frame-custom-count hidden/);
   assert.match(mainSource, /resampleCurrentVideo\(\{ frame_count: selected \}\)/);
   assert.match(stylesSource, /\.h3ps-frame-custom-count \{[^}]*width:42px;[^}]*text-align:center;/);
+});
+
+test("legacy Continuum draft state migrates to schema v2 without losing plan or bodies", () => {
+  const storage = memoryStorage();
+  saveModeDrafts(storage, {
+    T2VA: {
+      brief: "Legacy sequence.",
+      prompt: "",
+      single_prompt: "Single prompt.",
+      generation_target: "continuum",
+      continuum: {
+        schema_version: 1,
+        settings: { schema_version: 1, chunks: 2, chunk_seconds: 5, total_seconds: 10 },
+        plan: {
+          schema_version: 1,
+          global: { sequence_preamble: "Legacy global." },
+          chunks: [],
+        },
+        prompts: ["Legacy one.", "Legacy two."],
+      },
+    },
+  });
+  const loaded = loadModeDrafts(storage).T2VA.continuum;
+  assert.equal(loaded.schema_version, 2);
+  assert.equal(loaded.settings.schema_version, 2);
+  assert.equal(loaded.migrated_from_schema_version, 1);
+  assert.equal(loaded.preamble, "Legacy global.");
+  assert.deepEqual(loaded.prompts, ["Legacy one.", "Legacy two."]);
+});
+
+test("Continuum draft sanitizer never silently truncates semantic state", () => {
+  const storage = memoryStorage();
+  saveModeDrafts(storage, {
+    T2VA: {
+      brief: "Oversize sequence.",
+      prompt: "",
+      single_prompt: "Single prompt.",
+      generation_target: "continuum",
+      continuum: {
+        schema_version: 2,
+        settings: { schema_version: 2, chunks: 1, chunk_seconds: 5, total_seconds: 5 },
+        plan: {
+          schema_version: 2,
+          global: { sequence_preamble: "Global." },
+          chunks: [],
+        },
+        preamble: "p".repeat(20001),
+        prompts: ["One."],
+      },
+    },
+  });
+  assert.equal(loadModeDrafts(storage).T2VA.continuum, null);
+});
+
+test("invalid saved Continuum inventory invalidates the draft instead of dropping the source-drift guard", () => {
+  const storage = memoryStorage();
+  saveModeDrafts(storage, {
+    Reference: {
+      brief: "Reference sequence.",
+      prompt: "",
+      single_prompt: "Single prompt.",
+      generation_target: "continuum",
+      continuum: {
+        schema_version: 2,
+        settings: { schema_version: 2, chunks: 2, chunk_seconds: 5, total_seconds: 10 },
+        plan: {
+          schema_version: 2,
+          global: { sequence_preamble: "Global." },
+          chunks: [],
+        },
+        preamble: "Global.",
+        prompts: ["One.", "Two."],
+        downstream_reference_inventory: {
+          schema_version: 1,
+          items: [{ role: "not_a_real_role" }],
+        },
+      },
+    },
+  });
+  assert.equal(loadModeDrafts(storage).Reference.continuum, null);
 });
 
 test("video drafts preserve the 8000 character brief while Music keeps 2000", () => {
@@ -852,6 +1699,25 @@ test("text-only Direct models expose only T2VA", () => {
   for (const mode of ["I2VA", "FL2VA", "L2VA", "Reference", "Music3"]) {
     assert.equal(isGenerationModeAvailable(textOnly, mode), false);
   }
+  for (const mode of ["I2VA", "FL2VA", "L2VA", "Reference"]) {
+    assert.equal(isGenerationModeAvailable(textOnly, mode, {
+      generationTarget: "continuum",
+      hasVisualMedia: false,
+    }), true);
+    assert.equal(isGenerationModeAvailable(textOnly, mode, {
+      generationTarget: "continuum",
+      hasVisualMedia: true,
+    }), false);
+    assert.equal(isGenerationModeAvailable(textOnly, mode, {
+      generationTarget: "continuum",
+      hasVisualMedia: true,
+      continuumRefinement: true,
+    }), true);
+  }
+  assert.equal(isGenerationModeAvailable(textOnly, "Music3", {
+    generationTarget: "continuum",
+    hasVisualMedia: false,
+  }), false);
   assert.equal(isTextOnlyDirectModel(vision), false);
   assert.equal(isGenerationModeAvailable(vision, "Reference"), true);
   assert.equal(isGenerationModeAvailable({ family: "external", capabilities: { images: false } }, "Reference"), true);
@@ -873,6 +1739,7 @@ test("Generate and Refine payloads are built from state rather than Settings DOM
   assert.deepEqual(buildGeneratePayload(state, { creativeBrief: "A quiet shot.", seed: 3407 }), {
     session_id: state.sessionId,
     mode: "Reference",
+    generation_target: "single",
     duration_seconds: 8,
     aspect_ratio: "3:2",
     creative_brief: "A quiet shot.",
@@ -891,6 +1758,7 @@ test("Generate and Refine payloads are built from state rather than Settings DOM
   assert.deepEqual(buildRefinePayload(state, { currentPrompt: "Current", instruction: "Slower", creativeBrief: "Original brief", seed: 99 }), {
     session_id: state.sessionId,
     mode: "Reference",
+    generation_target: "single",
     duration_seconds: 8,
     aspect_ratio: "3:2",
     creative_brief: "Original brief",
@@ -952,6 +1820,107 @@ test("Generate and Refine payloads are built from state rather than Settings DOM
   assert.equal(Object.hasOwn(buildGeneratePayload(state, { creativeBrief: "Direct brief", seed: 2 }), "reasoning_effort"), false);
 });
 
+test("Continuum generation and refinement require a real supported H3 Continuum sampler topology", () => {
+  assert.match(
+    mainSource,
+    /target\.status === "missing"[\s\S]{0,320}Add H3 Continuum Sampler V3\.4[\s\S]{0,320}before generating/,
+  );
+  assert.match(
+    mainSource,
+    /target\.status === "missing"[\s\S]{0,320}Add H3 Continuum Sampler V3\.4[\s\S]{0,320}before refining/,
+  );
+  assert.doesNotMatch(
+    mainSource,
+    /target\.status === "selected"[\s\S]{0,120}\{ schema_version: 1, items: \[\] \}/,
+  );
+});
+
+test("Continuum payloads and drafts preserve Timeline state and downstream inventory", () => {
+  const state = createStudioState({ sessionId: "continuum-session", storage: memoryStorage() });
+  state.mode = "T2VA";
+  state.generationTarget = "continuum";
+  state.continuumChunks = 2;
+  state.continuumChunkSeconds = 6.5;
+  state.continuumSequence = {
+    schema_version: 2,
+    settings: { schema_version: 2, chunks: 2, chunk_seconds: 6.5, total_seconds: 13 },
+    plan: { schema_version: 2, global: { sequence_preamble: "Global." }, chunks: [] },
+    preamble: "Global.",
+    prompts: ["Prompt one.", "Prompt two."],
+  };
+  selectModelState(state, { id: "direct.gguf", family: "gguf", capabilities: { audio: false } });
+  const inventory = {
+    schema_version: 1,
+    items: [{
+      tag: "<Picture 1>",
+      kind: "image",
+      source: "workflow",
+      visible_to_model: false,
+      role: "reference_image",
+    }],
+  };
+  const generated = buildGeneratePayload(state, {
+    creativeBrief: "Continue one shot.",
+    seed: 11,
+    downstreamReferenceInventory: inventory,
+  });
+  assert.equal(generated.generation_target, "continuum");
+  assert.equal(generated.duration_seconds, 6.5);
+  assert.deepEqual(generated.continuum, { schema_version: 2, chunks: 2, chunk_seconds: 6.5 });
+  assert.equal(generated.downstream_reference_inventory, inventory);
+
+  const current = "Global.\n\n[0-6.5s]\nPrompt one.\n\n[6.5-13s]\nPrompt two.";
+  const refined = buildRefinePayload(state, {
+    currentPrompt: current,
+    instruction: "Slow the second chunk.",
+    creativeBrief: "Continue one shot.",
+    chunkIndex: 2,
+    seed: 12,
+    downstreamReferenceInventory: inventory,
+  });
+  assert.equal(refined.continuum.chunk_index, 2);
+  assert.equal(refined.continuum.plan, state.continuumSequence.plan);
+  assert.equal(refined.downstream_reference_inventory, inventory);
+  state.continuumSequence.downstream_reference_inventory = inventory;
+  const refinedWithSnapshot = buildRefinePayload(state, {
+    currentPrompt: current,
+    instruction: "Slow the second chunk.",
+    creativeBrief: "Continue one shot.",
+    chunkIndex: 2,
+    seed: 13,
+    downstreamReferenceInventory: inventory,
+  });
+  assert.equal(
+    refinedWithSnapshot.continuum.downstream_reference_inventory,
+    inventory,
+  );
+
+  const storage = memoryStorage();
+  saveModeDrafts(storage, {
+    T2VA: {
+      brief: "Continue one shot.",
+      prompt: current,
+      single_prompt: "A prior single prompt.",
+      generation_target: "continuum",
+      continuum: state.continuumSequence,
+    },
+  });
+  const loadedContinuum = loadModeDrafts(storage).T2VA.continuum;
+  assert.deepEqual(loadedContinuum.prompts, ["Prompt one.", "Prompt two."]);
+  assert.equal(loadedContinuum.schema_version, 2);
+  assert.equal(loadedContinuum.settings.schema_version, 2);
+  assert.equal(loadedContinuum.preamble, "Global.");
+  assert.deepEqual(
+    loadedContinuum.downstream_reference_inventory,
+    inventory,
+  );
+  assert.equal(loadModeDrafts(storage).T2VA.generation_target, "continuum");
+  assert.doesNotMatch(storage.entries()[MODE_DRAFTS_STORAGE_KEY], /api_key|connection_id/);
+  assert.match(mainSource, /data-generation-target="continuum"/);
+  assert.match(mainSource, /data-apply-continuum/);
+  assert.match(mainSource, /Only the selected chunk changes/);
+});
+
 test("Ollama remote host controls stay collapsed and disclosure state survives refresh renders", () => {
   assert.match(mainSource, /data-ollama-host-settings[^>]*\$\{studio\.ollamaHostSettingsOpen \? "open" : ""\}/);
   assert.match(mainSource, /data-ollama-host-form/);
@@ -961,6 +1930,10 @@ test("Ollama remote host controls stay collapsed and disclosure state survives r
   assert.match(mainSource, /data-ollama-storage-help \$\{studio\.ollamaStorageHelpOpen \? "open" : ""\}/);
   assert.match(mainSource, /studio\.ollamaStorageHelpOpen = !ollamaStorageSummary\.closest\("details"\)\.open/);
   assert.match(skinSource, /\.h3ps-ollama-host-settings/);
+});
+
+test("generation target obeys the hidden attribute in Music 3", () => {
+  assert.match(stylesSource, /\.h3ps-generation-target\[hidden\]\s*\{\s*display\s*:\s*none\s*;?\s*\}/);
 });
 
 test("automatic Ollama refresh renders preserve the unsaved host field value", () => {
@@ -1208,6 +2181,9 @@ test("Music 3 drafts and payload keep lyrics separate from H3 state", () => {
     brief: "Oboe chamber pop",
     lyrics: "[Verse]\nWindows glow",
     prompt: "### Global Metadata\n...",
+    single_prompt: "### Global Metadata\n...",
+    generation_target: "single",
+    continuum: null,
   });
   const state = createStudioState({ sessionId: "music-session", storage });
   state.mode = "Music3";
@@ -1281,15 +2257,18 @@ test("active requests block add, reorder, and mode switching", () => {
   assert.match(mainSource, /drop[\s\S]{0,180}if \(studio\.requestBusy\) return/);
   assert.match(mainSource, /if \(!files\.length \|\| studio\.requestBusy\) return/);
   assert.match(mainSource, /studio\.requestBusy = busy;[\s\S]{0,120}syncModeAvailability\(\)/);
-  assert.match(mainSource, /const unavailable = !isGenerationModeAvailable[\s\S]{0,180}control\.disabled = studio\.requestBusy \|\| unavailable/);
+  assert.match(mainSource, /const unavailable = !isGenerationModeAvailable[\s\S]{0,320}control\.disabled = studio\.requestBusy \|\| unavailable/);
 });
 
-test("text-only Direct UI disables visual and Music modes and explains the fallback", () => {
+test("text-only Direct UI distinguishes single visual analysis from workflow-only Continuum", () => {
   assert.match(mainSource, /function syncModeAvailability\(\)/);
   assert.match(mainSource, /data-workspace[\s\S]{0,220}control\.dataset\.workspace === "music"/);
-  assert.match(mainSource, /Text-only model · T2VA available/);
+  assert.match(mainSource, /Text-only model · T2VA \+ workflow-only Continuum/);
+  assert.match(mainSource, /savedContinuumRefinement[\s\S]{0,420}continuumRefinement: savedContinuumRefinement/);
   assert.match(mainSource, /Switched to T2VA/);
   assert.match(mainSource, /if \(!generationModeIsAvailable\(\)\) return/);
+  assert.match(mainSource, /generationModeIsAvailable\(\{ continuumRefinement \}\)/);
+  assert.match(mainSource, /workflow-only Continuum conditioning does not require vision/);
   assert.match(stylesSource, /\.h3ps-modes button:disabled/);
   assert.match(skinSource, /\.h3ps-workspaces button:disabled/);
 });
@@ -1317,4 +2296,82 @@ test("prompt refinement keeps actions above a vertically resizable editor", () =
   assert.match(mainSource, /data-refine-helper[\s\S]{0,160}data-refine-media-note/);
   assert.doesNotMatch(mainSource, /refine_height|refineHeight/);
   assert.match(stylesSource, /\.h3ps-refine\[data-refine-panel\] textarea \{[^}]*min-height: 72px;[^}]*resize: vertical;/);
+});
+
+
+test("Continuum Reference UI exposes active workflow image import controls", () => {
+  assert.match(mainSource, /Active workflow images/);
+  assert.match(mainSource, /data-workflow-ref-add-all/);
+  assert.match(mainSource, /Add active workflow refs/);
+  assert.match(mainSource, /fetchComfyImageFile/);
+  assert.match(mainSource, /bindActiveWorkflowReferenceMedia/);
+  assert.match(stylesSource, /\.h3ps-workflow-references/);
+  assert.match(skinSource, /\.h3ps-workflow-references/);
+});
+
+test("Studio state owns transient workflow-reference media bindings", () => {
+  const state = createStudioState({ sessionId: "workflow-bindings", storage: memoryStorage() });
+  assert.deepEqual(state.workflowReferenceBindings, {});
+  assert.equal(state.workflowReferenceImportBusy, false);
+});
+
+
+test("Continuum saved inventory accepts a new temporary Writer asset ID only when model visibility and workflow source stay the same", () => {
+  const saved = {
+    schema_version: 1,
+    items: [{
+      role: "reference_image",
+      kind: "image",
+      source: "workflow",
+      visible_to_model: true,
+      tag: "<Picture 1>",
+      source_node_id: 41,
+      source_node_class: "ImageConveyor",
+      source_output_name: "ref_image_1",
+      source_slot: 6,
+      source_identity: "image-conveyor-ref-v1:1111111111111111",
+      model_asset_id: "old-session-asset",
+    }],
+  };
+  const rematerialized = structuredClone(saved);
+  rematerialized.items[0].model_asset_id = "new-session-asset";
+  assert.equal(sameContinuumReferenceInventory(saved, rematerialized), true);
+
+  const missing = structuredClone(rematerialized);
+  missing.items[0].visible_to_model = false;
+  delete missing.items[0].model_asset_id;
+  assert.equal(sameContinuumReferenceInventory(saved, missing), false);
+
+  const changedSource = structuredClone(rematerialized);
+  changedSource.items[0].source_identity = "image-conveyor-ref-v1:2222222222222222";
+  assert.equal(sameContinuumReferenceInventory(saved, changedSource), false);
+
+  const unfingerprintedSaved = structuredClone(saved);
+  delete unfingerprintedSaved.items[0].source_identity;
+  const unfingerprintedActive = structuredClone(unfingerprintedSaved);
+  unfingerprintedActive.items[0].model_asset_id = "another-session-asset";
+  assert.equal(sameContinuumReferenceInventory(unfingerprintedSaved, unfingerprintedActive), false);
+});
+
+test("manual replacement of an imported workflow copy drops its binding after a successful upload", () => {
+  assert.match(
+    mainSource,
+    /if \(replaceAssetId\) forgetWorkflowReferenceAsset\(replaceAssetId\);/,
+  );
+});
+
+
+test("workflow reference import routes reviewed transforms through backend materialization", () => {
+  assert.match(mainSource, /candidate\.materialization_plan/);
+  assert.match(mainSource, /materializeWorkflowImage/);
+  assert.match(mainSource, /Unsupported resize method/);
+  assert.match(mainSource, /Dynamic resize inputs/);
+});
+
+
+test("bound transformed workflow references preview the exact Writer-visible asset", () => {
+  assert.match(
+    mainSource,
+    /binding\.state === "current" && binding\.asset\?\.preview_url/,
+  );
 });

--- a/tests/test_api_provider_backend.py
+++ b/tests/test_api_provider_backend.py
@@ -3,6 +3,7 @@ import threading
 import time
 import unittest
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from unittest.mock import patch
 
 from backend.models.api_provider_backend import (
     ApiConnection,
@@ -264,6 +265,25 @@ class ApiProviderBackendTests(unittest.TestCase):
         self.assertEqual(raised.exception.code, "API_MODEL_NOT_FOUND")
         self.assertEqual(raised.exception.details["status"], 404)
 
+    def test_private_lan_custom_endpoint_can_be_detected_as_lm_studio(self):
+        connection = self._connection()
+        connection.base_url = "http://192.168.178.20:1234/v1"
+        response = {
+            "models": [
+                {
+                    "type": "llm",
+                    "key": "lan-lm-studio-model",
+                    "max_context_length": 262144,
+                    "capabilities": {"vision": True},
+                }
+            ]
+        }
+        with patch.object(self.backend, "_request_json", return_value=(response, {})) as request_json:
+            metadata = self.backend._local_custom_model_metadata(connection)
+        request_json.assert_called_once_with(connection, "GET", "/api/v1/models")
+        self.assertEqual(connection.compatibility_profile, "lm_studio")
+        self.assertIn("lan-lm-studio-model", metadata)
+
     def test_loopback_custom_enriches_lm_studio_vision_metadata(self):
         result = self.backend.probe({
             "preset": "custom",
@@ -499,6 +519,14 @@ class ApiProviderBackendTests(unittest.TestCase):
         self.assertEqual(plan["kv_cache"], "provider")
         self.assertEqual(plan["context_profile"], "provider")
         self.assertEqual(plan["max_output_tokens"], 2_048)
+        continuum_plan = self.backend.preflight(
+            model,
+            {**assembled, "input": {"mode": "T2VA", "continuum_stage": "plan"}},
+            context_profile="auto",
+            kv_cache="auto",
+            thinking=False,
+        )
+        self.assertEqual(continuum_plan["max_output_tokens"], 8_192)
         music_plan = self.backend.preflight(
             model,
             {**assembled, "input": {"mode": "Music3"}},

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -76,6 +76,29 @@ class ContextPlanTests(unittest.TestCase):
         self.assertEqual(result["context_profile"], "standard")
         self.assertEqual(result["max_output_tokens"], 2048)
 
+    def test_continuum_planner_gets_dedicated_large_output_budget(self):
+        assembled = request(mode="T2VA")
+        assembled["input"]["continuum_stage"] = "plan"
+        result = plan_context(
+            assembled,
+            {"recommended_context": "standard"},
+            requested_context="auto",
+            requested_kv_cache="q8",
+            thinking=False,
+        )
+        self.assertEqual(result["max_output_tokens"], 8192)
+        self.assertEqual(result["reserved_output_tokens"], 8704)
+
+        assembled["input"]["continuum_stage"] = "plan_repair"
+        repair = plan_context(
+            assembled,
+            {"recommended_context": "standard"},
+            requested_context="auto",
+            requested_kv_cache="q8",
+            thinking=False,
+        )
+        self.assertEqual(repair["max_output_tokens"], 8192)
+
     def test_music_keeps_its_separate_non_thinking_output_budget(self):
         result = plan_context(
             request(mode="Music3"),

--- a/tests/test_continuum.py
+++ b/tests/test_continuum.py
@@ -1,0 +1,1659 @@
+from __future__ import annotations
+
+import copy
+import json
+import unittest
+from unittest.mock import patch
+
+from backend.assembly import AssemblyError
+from backend.continuum import (
+    CONTINUUM_SCHEMA_VERSION,
+    ContinuumError,
+    continuum_chunk_format_violations,
+    apply_continuum_refinement,
+    assemble_continuum_chunk_request,
+    assemble_continuum_plan_repair_request,
+    assemble_continuum_plan_request,
+    assemble_continuum_refinement,
+    format_timeline_seconds,
+    generation_target,
+    parse_chunk_prompts,
+    parse_sequence_plan,
+    recover_sequence_plan_contract,
+    parse_timeline_sequence,
+    prompt_hash,
+    resolved_chunk_prompt,
+    sequence_result,
+    serialize_chunk_prompts,
+    serialize_timeline,
+    validate_continuum_settings,
+    validate_continuum_mode_topology,
+    validate_generated_chunk,
+    validate_saved_downstream_inventory,
+    validate_sequence_plan,
+    validate_sequence_reference_scope,
+)
+from backend.references import (
+    bind_downstream_reference_inventory,
+    effective_reference_tags,
+    model_media_labels,
+    normalize_downstream_reference_inventory,
+    reference_policy,
+)
+
+
+SESSION_ID = "11111111-2222-4333-8444-555555555555"
+
+
+def manifest(mode="T2VA", assets=None):
+    return {
+        "session_id": SESSION_ID,
+        "mode": mode,
+        "assets": list(assets or []),
+        "valid": True,
+        "violations": [],
+    }
+
+
+def picture(number=1):
+    return {
+        "id": f"picture-{number}",
+        "type": "image",
+        "filename": f"picture-{number}.png",
+        "reference": f"<Picture {number}>",
+        "content_url": f"/picture-{number}",
+        "frames": [],
+        "prepared_width": 1024,
+        "prepared_height": 768,
+    }
+
+
+def video(number=1):
+    return {
+        "id": f"video-{number}",
+        "type": "video",
+        "filename": f"video-{number}.mp4",
+        "reference": f"<Video {number}>",
+        "content_url": f"/video-{number}",
+        "frames": [],
+        "contact_sheet_width": 1152,
+        "contact_sheet_height": 768,
+    }
+
+
+def downstream_inventory(
+    pictures=0,
+    *,
+    first_frame=False,
+    last_frame=False,
+    video_reference=False,
+    reference_audio=False,
+    driving_audio=False,
+    visible=False,
+):
+    items = [
+        {
+            "tag": f"<Picture {index}>",
+            "kind": "image",
+            "source": "workflow",
+            "visible_to_model": visible,
+            "role": "reference_image",
+            "input_name": f"reference_image_{index}",
+            "source_node_id": 100 + index,
+            "source_node_class": "LoadImage",
+            "source_output_name": "IMAGE",
+            "source_slot": 0,
+        }
+        for index in range(1, pictures + 1)
+    ]
+    keyframe_index = 0
+    for enabled, role, kind, input_name in (
+        (first_frame, "first_frame", "image", "first_frame"),
+        (last_frame, "last_frame", "image", "last_frame"),
+        (video_reference, "video_reference", "video", "reference_video_1"),
+        (reference_audio, "reference_audio", "audio", "reference_audio_1"),
+        (driving_audio, "driving_audio", "audio", "driving_audio"),
+    ):
+        if not enabled:
+            continue
+        tag = None
+        if pictures == 0 and role in {"first_frame", "last_frame"}:
+            keyframe_index += 1
+            tag = f"<Picture {keyframe_index}>"
+        elif role == "video_reference":
+            tag = "<Video 1>"
+        elif role == "reference_audio":
+            tag = "<Audio 1>"
+        item = {
+            "kind": kind,
+            "source": "workflow",
+            "visible_to_model": False,
+            "role": role,
+            "input_name": input_name,
+            "source_node_id": 900 + len(items),
+            "source_node_class": "TestSource",
+            "source_output_name": kind.upper(),
+            "source_slot": 0,
+        }
+        if tag:
+            item["tag"] = tag
+        items.append(item)
+    return {"schema_version": 1, "items": items}
+
+
+def settings(chunks=3, chunk_seconds=5.0):
+    return {
+        "schema_version": CONTINUUM_SCHEMA_VERSION,
+        "chunks": chunks,
+        "chunk_seconds": float(chunk_seconds),
+        "total_seconds": chunks * float(chunk_seconds),
+    }
+
+
+def plan_v2(chunks=3, *, preamble="Stable cinematic identity, wardrobe, environment, camera language, and room tone persist."):
+    return {
+        "schema_version": CONTINUUM_SCHEMA_VERSION,
+        "global": {
+            "sequence_preamble": preamble,
+            "continuity_anchors": "Same subject, location, wardrobe, light, camera axis, and room tone.",
+            "persistent_constraints": "Preserve identity and requested exclusions throughout.",
+            "subject_anchors": [],
+        },
+        "chunks": [
+            {
+                "continuity": "initial" if index == 1 else "continuous",
+                "transition": "",
+                "start_state": f"Start state {index}.",
+                "action": f"Action {index}.",
+                "end_state": f"End state {index}.",
+            }
+            for index in range(1, chunks + 1)
+        ],
+    }
+
+
+def plan_v1(chunks=3):
+    return {
+        "schema_version": 1,
+        "global": {
+            "continuity_anchors": "Same subject and place.",
+            "persistent_constraints": "Preserve continuity.",
+            "reference_assignments": [],
+            "subject_anchors": [],
+        },
+        "chunks": [
+            {
+                "index": index,
+                "continuity": "initial" if index == 1 else "continuous",
+                "transition": "",
+                "start_state": f"Start {index}.",
+                "action": f"Action {index}.",
+                "end_state": f"End {index}.",
+            }
+            for index in range(1, chunks + 1)
+        ],
+    }
+
+
+def body(mode="T2VA", *, chunks=3, chunk_seconds=5, brief="One continuous shot.", inventory=None):
+    value = {
+        "session_id": SESSION_ID,
+        "mode": mode,
+        "generation_target": "continuum",
+        "continuum": {
+            "schema_version": CONTINUUM_SCHEMA_VERSION,
+            "chunks": chunks,
+            "chunk_seconds": chunk_seconds,
+        },
+        "duration_seconds": chunk_seconds,
+        "aspect_ratio": "16:9",
+        "creative_brief": brief,
+    }
+    value["downstream_reference_inventory"] = (
+        downstream_inventory(0) if inventory is None else inventory
+    )
+    return value
+
+
+class ContinuumSettingsTests(unittest.TestCase):
+    def test_generation_target_defaults_to_single_clip(self):
+        self.assertEqual(generation_target({}), "single")
+        self.assertEqual(generation_target({"generation_target": "continuum"}), "continuum")
+
+    def test_native_boundary_values_are_valid_and_legacy_settings_migrate(self):
+        for schema in (1, CONTINUUM_SCHEMA_VERSION):
+            for chunks in (1, 16):
+                for seconds in (4, 30):
+                    with self.subTest(schema=schema, chunks=chunks, seconds=seconds):
+                        value = validate_continuum_settings({
+                            "continuum": {
+                                "schema_version": schema,
+                                "chunks": chunks,
+                                "chunk_seconds": seconds,
+                            }
+                        })
+                        self.assertEqual(value["schema_version"], CONTINUUM_SCHEMA_VERSION)
+                        self.assertEqual(value["chunks"], chunks)
+                        self.assertEqual(value["chunk_seconds"], float(seconds))
+                        self.assertEqual(value["total_seconds"], chunks * seconds)
+
+    def test_invalid_native_values_are_rejected(self):
+        invalid = (
+            {"chunks": 0, "chunk_seconds": 5},
+            {"chunks": 17, "chunk_seconds": 5},
+            {"chunks": True, "chunk_seconds": 5},
+            {"chunks": 3, "chunk_seconds": 3.9},
+            {"chunks": 3, "chunk_seconds": 30.1},
+            {"chunks": 3, "chunk_seconds": True},
+        )
+        for value in invalid:
+            with self.subTest(value=value), self.assertRaises(ContinuumError):
+                validate_continuum_settings({"continuum": {"schema_version": 2, **value}})
+
+    def test_total_sequence_duration_is_not_limited_to_twenty_seconds(self):
+        value = validate_continuum_settings({
+            "continuum": {"schema_version": 2, "chunks": 12, "chunk_seconds": 5}
+        })
+        self.assertEqual(value["total_seconds"], 60)
+
+
+class DownstreamReferenceInventoryTests(unittest.TestCase):
+    def test_reference_images_are_compact_and_keyframes_do_not_own_picture_tags(self):
+        value = normalize_downstream_reference_inventory(
+            downstream_inventory(
+                2,
+                first_frame=True,
+                last_frame=True,
+                video_reference=True,
+                driving_audio=True,
+            )
+        )
+        pictures = [item for item in value["items"] if item["role"] == "reference_image"]
+        self.assertEqual([item["tag"] for item in pictures], ["<Picture 1>", "<Picture 2>"])
+        self.assertEqual(
+            [(item["role"], item.get("tag")) for item in value["items"] if item["role"] != "reference_image"],
+            [
+                ("first_frame", None),
+                ("last_frame", None),
+                ("video_reference", "<Video 1>"),
+                ("driving_audio", None),
+            ],
+        )
+
+    def test_optional_source_identity_is_preserved_and_must_be_nonempty_text(self):
+        value = downstream_inventory(1)
+        value["items"][0]["source_identity"] = "image-conveyor-ref-v1:0123456789abcdef"
+        normalized = normalize_downstream_reference_inventory(value)
+        self.assertEqual(
+            normalized["items"][0]["source_identity"],
+            "image-conveyor-ref-v1:0123456789abcdef",
+        )
+
+        for invalid in ("", "   ", 7):
+            broken = downstream_inventory(1)
+            broken["items"][0]["source_identity"] = invalid
+            with self.subTest(invalid=invalid), self.assertRaisesRegex(ValueError, "source_identity"):
+                normalize_downstream_reference_inventory(broken)
+
+    def test_saved_inventory_source_identity_upgrades_legacy_and_then_detects_drift(self):
+        active = downstream_inventory(1)
+        active["items"][0]["source_identity"] = "image-conveyor-ref-v1:1111111111111111"
+
+        legacy = downstream_inventory(1)
+        upgraded = validate_saved_downstream_inventory(legacy, active)
+        self.assertEqual(
+            upgraded["items"][0]["source_identity"],
+            "image-conveyor-ref-v1:1111111111111111",
+        )
+
+        same = downstream_inventory(1)
+        same["items"][0]["source_identity"] = "image-conveyor-ref-v1:1111111111111111"
+        self.assertEqual(
+            validate_saved_downstream_inventory(same, active)["items"][0]["source_identity"],
+            "image-conveyor-ref-v1:1111111111111111",
+        )
+
+        changed = downstream_inventory(1)
+        changed["items"][0]["source_identity"] = "image-conveyor-ref-v1:2222222222222222"
+        with self.assertRaises(ContinuumError) as raised:
+            validate_saved_downstream_inventory(changed, active)
+        self.assertEqual(raised.exception.code, "CONTINUUM_REFERENCE_SOURCE_DRIFT")
+
+        no_fingerprint = downstream_inventory(1)
+        with self.assertRaises(ContinuumError) as raised:
+            validate_saved_downstream_inventory(same, no_fingerprint)
+        self.assertEqual(raised.exception.code, "CONTINUUM_REFERENCE_SOURCE_DRIFT")
+
+    def test_model_visible_source_can_be_rematerialized_under_a_new_temporary_asset_id(self):
+        saved = downstream_inventory(1)
+        saved["items"][0].update({
+            "source_identity": "image-conveyor-ref-v1:1111111111111111",
+            "visible_to_model": True,
+            "model_asset_id": "old-session-asset",
+        })
+        active = copy.deepcopy(saved)
+        active["items"][0]["model_asset_id"] = "new-session-asset"
+
+        upgraded = validate_saved_downstream_inventory(saved, active)
+        self.assertEqual(upgraded["items"][0]["model_asset_id"], "new-session-asset")
+
+        missing = copy.deepcopy(active)
+        missing["items"][0]["visible_to_model"] = False
+        missing["items"][0].pop("model_asset_id")
+        with self.assertRaises(ContinuumError) as raised:
+            validate_saved_downstream_inventory(saved, missing)
+        self.assertEqual(raised.exception.code, "CONTINUUM_REFERENCE_SOURCE_DRIFT")
+
+        unfingerprinted_saved = downstream_inventory(1)
+        unfingerprinted_saved["items"][0].update({
+            "visible_to_model": True,
+            "model_asset_id": "old-session-asset",
+        })
+        unfingerprinted_active = copy.deepcopy(unfingerprinted_saved)
+        unfingerprinted_active["items"][0]["model_asset_id"] = "new-session-asset"
+        with self.assertRaises(ContinuumError) as raised:
+            validate_saved_downstream_inventory(unfingerprinted_saved, unfingerprinted_active)
+        self.assertEqual(raised.exception.code, "CONTINUUM_REFERENCE_SOURCE_DRIFT")
+
+    def test_gapped_public_picture_numbers_are_rejected(self):
+        value = downstream_inventory(2)
+        value["items"][1]["tag"] = "<Picture 3>"
+        with self.assertRaisesRegex(ValueError, "compact public tags"):
+            normalize_downstream_reference_inventory(value)
+
+    def test_declared_workflow_pictures_override_unrelated_manifest_picture_numbers(self):
+        request_input = {
+            "mode": "Reference",
+            "generation_target": "continuum",
+            "media_manifest": manifest("Reference", [picture(1), video(1)]),
+            "downstream_reference_inventory": downstream_inventory(2),
+        }
+        self.assertEqual(
+            effective_reference_tags(request_input, continuum=True),
+            {"<Picture 1>", "<Picture 2>"},
+        )
+
+    def test_model_visible_binding_requires_explicit_existing_matching_asset(self):
+        value = downstream_inventory(1)
+        value["items"][0].update({
+            "visible_to_model": True,
+            "model_asset_id": "picture-1",
+        })
+        bound = bind_downstream_reference_inventory(
+            value,
+            manifest("Reference", [picture(1)]),
+        )
+        self.assertEqual(bound["items"][0]["model_asset_id"], "picture-1")
+        self.assertTrue(bound["items"][0]["visible_to_model"])
+
+    def test_visible_flag_without_model_asset_binding_is_rejected(self):
+        value = downstream_inventory(1)
+        value["items"][0]["visible_to_model"] = True
+        with self.assertRaisesRegex(ValueError, "visible_to_model must be true exactly when model_asset_id is set"):
+            normalize_downstream_reference_inventory(value)
+
+    def test_missing_wrong_type_and_duplicate_model_asset_bindings_are_rejected(self):
+        missing = downstream_inventory(1)
+        missing["items"][0].update({"visible_to_model": True, "model_asset_id": "missing"})
+        with self.assertRaisesRegex(ValueError, "missing Prompt Writer media asset"):
+            bind_downstream_reference_inventory(missing, manifest("Reference", [picture(1)]))
+
+        wrong_type = downstream_inventory(1)
+        wrong_type["items"][0].update({"visible_to_model": True, "model_asset_id": "video-1"})
+        with self.assertRaisesRegex(ValueError, "requires 'image'"):
+            bind_downstream_reference_inventory(wrong_type, manifest("Reference", [video(1)]))
+
+        duplicate = downstream_inventory(2)
+        for item in duplicate["items"]:
+            item.update({"visible_to_model": True, "model_asset_id": "picture-1"})
+        with self.assertRaisesRegex(ValueError, "bound to more than one downstream H3 conditioning input"):
+            bind_downstream_reference_inventory(duplicate, manifest("Reference", [picture(1)]))
+
+    def test_unbound_analysis_media_never_inherits_downstream_picture_identity(self):
+        labels = model_media_labels(
+            manifest("Reference", [picture(1)]),
+            downstream_inventory(1),
+            mode="Reference",
+        )
+        self.assertEqual(
+            labels["picture-1"],
+            "Analysis image 1 (no downstream public reference identity)",
+        )
+
+    def test_explicitly_bound_analysis_media_inherits_exact_downstream_picture_identity(self):
+        value = downstream_inventory(1)
+        value["items"][0].update({
+            "visible_to_model": True,
+            "model_asset_id": "picture-1",
+        })
+        bound = bind_downstream_reference_inventory(
+            value,
+            manifest("Reference", [picture(1)]),
+        )
+        labels = model_media_labels(
+            manifest("Reference", [picture(1)]),
+            bound,
+            mode="Reference",
+        )
+        self.assertEqual(labels["picture-1"], "<Picture 1>")
+
+    def test_non_reference_continuum_media_identity_requires_explicit_binding(self):
+        inventory = downstream_inventory(0, first_frame=True)
+        unbound = model_media_labels(
+            manifest("I2VA", [picture(1)]),
+            inventory,
+            mode="I2VA",
+        )
+        self.assertEqual(
+            unbound["picture-1"],
+            "Analysis image 1 (no downstream public reference identity)",
+        )
+
+        inventory["items"][0].update({
+            "visible_to_model": True,
+            "model_asset_id": "picture-1",
+        })
+        bound_inventory = bind_downstream_reference_inventory(
+            inventory,
+            manifest("I2VA", [picture(1)]),
+        )
+        bound = model_media_labels(
+            manifest("I2VA", [picture(1)]),
+            bound_inventory,
+            mode="I2VA",
+        )
+        self.assertEqual(bound["picture-1"], "<Picture 1>")
+
+    def test_continuum_uses_only_downstream_public_tags_when_inventory_is_declared(self):
+        request_input = {
+            "mode": "Reference",
+            "generation_target": "continuum",
+            "media_manifest": manifest("Reference", [video(1)]),
+            "downstream_reference_inventory": downstream_inventory(
+                1,
+                video_reference=True,
+                reference_audio=True,
+                driving_audio=True,
+            ),
+        }
+        self.assertEqual(
+            effective_reference_tags(request_input, continuum=True),
+            {"<Picture 1>", "<Video 1>", "<Audio 1>"},
+        )
+
+    def test_keyframes_own_picture_tags_only_when_reference_images_are_absent(self):
+        keyframes = normalize_downstream_reference_inventory(
+            downstream_inventory(0, first_frame=True, last_frame=True)
+        )
+        self.assertEqual(
+            [(item["role"], item.get("tag")) for item in keyframes["items"]],
+            [("first_frame", "<Picture 1>"), ("last_frame", "<Picture 2>")],
+        )
+
+        hybrid = normalize_downstream_reference_inventory(
+            downstream_inventory(2, first_frame=True, last_frame=True)
+        )
+        self.assertEqual(
+            [(item["role"], item.get("tag")) for item in hybrid["items"]],
+            [
+                ("reference_image", "<Picture 1>"),
+                ("reference_image", "<Picture 2>"),
+                ("first_frame", None),
+                ("last_frame", None),
+            ],
+        )
+
+    def test_video_and_reference_audio_own_public_tags_while_driving_audio_stays_untagged(self):
+        value = normalize_downstream_reference_inventory(
+            downstream_inventory(
+                0,
+                video_reference=True,
+                reference_audio=True,
+                driving_audio=True,
+            )
+        )
+        self.assertEqual(
+            [(item["role"], item.get("tag")) for item in value["items"]],
+            [
+                ("video_reference", "<Video 1>"),
+                ("reference_audio", "<Audio 1>"),
+                ("driving_audio", None),
+            ],
+        )
+
+        broken = downstream_inventory(0, reference_audio=True)
+        broken["items"][0]["tag"] = "<Audio 2>"
+        with self.assertRaisesRegex(ValueError, "Reference Audio must use public tag <Audio 1>"):
+            normalize_downstream_reference_inventory(broken)
+
+    def test_continuum_reference_policy_requires_active_reference_audio_and_keeps_it_mutable_by_name(self):
+        inventory = downstream_inventory(1, reference_audio=True)
+        generated = {
+            "mode": "Reference",
+            "generation_target": "continuum",
+            "creative_brief": "Use the image identity and the reference audio character.",
+            "media_manifest": manifest("Reference", []),
+            "downstream_reference_inventory": inventory,
+        }
+        policy = reference_policy(generated)
+        self.assertEqual(policy.required, {"<Picture 1>", "<Audio 1>"})
+        self.assertEqual(policy.allowed, {"<Picture 1>", "<Audio 1>"})
+
+        refined = {
+            **generated,
+            "current_prompt": "Keep <Picture 1> and <Audio 1>.",
+            "instruction": "Replace the role of <Audio 1>.",
+        }
+        policy = reference_policy(refined)
+        self.assertEqual(policy.required, {"<Picture 1>"})
+        self.assertEqual(policy.mutable, {"<Audio 1>"})
+
+    def test_invalid_hybrid_keyframe_picture_identity_is_rejected(self):
+        value = downstream_inventory(1, first_frame=True)
+        value["items"][1]["tag"] = "<Picture 2>"
+        with self.assertRaisesRegex(ValueError, "must not own public <Picture N> tags"):
+            normalize_downstream_reference_inventory(value)
+
+
+class ContinuumModeTopologyTests(unittest.TestCase):
+    def test_temporal_modes_require_matching_first_last_wiring(self):
+        cases = (
+            ("T2VA", downstream_inventory(0), True),
+            ("T2VA", downstream_inventory(1), False),
+            ("T2VA", downstream_inventory(0, first_frame=True), False),
+            ("I2VA", downstream_inventory(0, first_frame=True), True),
+            ("I2VA", downstream_inventory(2, first_frame=True), True),
+            ("I2VA", downstream_inventory(0), False),
+            ("I2VA", downstream_inventory(0, first_frame=True, last_frame=True), False),
+            ("FL2VA", downstream_inventory(0, first_frame=True, last_frame=True), True),
+            ("FL2VA", downstream_inventory(1, first_frame=True, last_frame=True), True),
+            ("FL2VA", downstream_inventory(0, first_frame=True), False),
+            ("L2VA", downstream_inventory(0, last_frame=True), True),
+            ("L2VA", downstream_inventory(1, last_frame=True), True),
+            ("L2VA", downstream_inventory(0, first_frame=True, last_frame=True), False),
+        )
+        for mode, inventory, valid in cases:
+            request_input = {
+                "downstream_reference_inventory": inventory,
+                "media_manifest": manifest(mode, []),
+            }
+            with self.subTest(mode=mode, inventory=inventory):
+                if valid:
+                    validate_continuum_mode_topology(mode, request_input)
+                else:
+                    with self.assertRaises(ContinuumError) as raised:
+                        validate_continuum_mode_topology(mode, request_input)
+                    self.assertEqual(
+                        raised.exception.code,
+                        "CONTINUUM_MODE_TOPOLOGY_MISMATCH",
+                    )
+
+    def test_t2va_rejects_reference_images_without_keyframes(self):
+        request_input = {
+            "downstream_reference_inventory": downstream_inventory(1),
+            "media_manifest": manifest("T2VA", []),
+        }
+        with self.assertRaises(ContinuumError) as raised:
+            validate_continuum_mode_topology("T2VA", request_input)
+        self.assertEqual(raised.exception.code, "CONTINUUM_MODE_TOPOLOGY_MISMATCH")
+        self.assertEqual(raised.exception.details["actual"]["reference_images"], 1)
+        self.assertEqual(raised.exception.details["required"]["reference_images"], 0)
+
+    def test_reference_mode_keeps_hybrid_keyframe_topologies_valid(self):
+        for inventory in (
+            downstream_inventory(1),
+            downstream_inventory(1, first_frame=True),
+            downstream_inventory(1, last_frame=True),
+            downstream_inventory(1, first_frame=True, last_frame=True),
+        ):
+            validate_continuum_mode_topology(
+                "Reference",
+                {
+                    "downstream_reference_inventory": inventory,
+                    "media_manifest": manifest("Reference", []),
+                },
+            )
+
+    def test_plan_assembly_rejects_fl2va_without_both_sampler_keyframes(self):
+        request = body(
+            "FL2VA",
+            brief="Reach the final composition.",
+            inventory=downstream_inventory(0, first_frame=True),
+        )
+        with patch("backend.assembly.STORE.manifest", return_value=manifest("FL2VA", [])):
+            with self.assertRaises(ContinuumError) as raised:
+                assemble_continuum_plan_request(request)
+        self.assertEqual(raised.exception.code, "CONTINUUM_MODE_TOPOLOGY_MISMATCH")
+        self.assertEqual(
+            raised.exception.details["required"],
+            {"first_frame": True, "last_frame": True},
+        )
+
+
+class SequencePlanTests(unittest.TestCase):
+    def test_v2_plan_injects_application_owned_indexes_and_reference_assignments(self):
+        value = validate_sequence_plan(
+            plan_v2(),
+            settings(),
+            expected_references={"<Picture 1>", "<Picture 2>"},
+        )
+        self.assertEqual([item["index"] for item in value["chunks"]], [1, 2, 3])
+        self.assertEqual(
+            [item["tag"] for item in value["global"]["reference_assignments"]],
+            ["<Picture 1>", "<Picture 2>"],
+        )
+
+    def test_planner_must_not_emit_application_owned_chunk_indexes(self):
+        value = plan_v2()
+        value["chunks"][0]["index"] = 1
+        with self.assertRaises(ContinuumError) as raised:
+            validate_sequence_plan(value, settings(), expected_references=set())
+        self.assertEqual(raised.exception.code, "INVALID_CONTINUUM_PLAN")
+
+    def test_sequence_preamble_is_required_for_new_plans_and_rejects_timeline_headers(self):
+        for preamble in ("", "[0-5s]\nBad"):
+            value = plan_v2(preamble=preamble)
+            with self.subTest(preamble=preamble), self.assertRaises(ContinuumError):
+                validate_sequence_plan(value, settings(), expected_references=set())
+
+    def test_internal_global_planning_text_may_be_empty_but_must_remain_text(self):
+        value = plan_v2()
+        value["global"]["continuity_anchors"] = ""
+        value["global"]["persistent_constraints"] = "   "
+        validated = validate_sequence_plan(value, settings(), expected_references=set())
+        self.assertEqual(validated["global"]["continuity_anchors"], "")
+        self.assertEqual(validated["global"]["persistent_constraints"], "")
+
+        for field in ("continuity_anchors", "persistent_constraints"):
+            invalid = plan_v2()
+            invalid["global"][field] = None
+            with self.subTest(field=field), self.assertRaises(ContinuumError) as raised:
+                validate_sequence_plan(invalid, settings(), expected_references=set())
+            self.assertEqual(raised.exception.details["field"], f"global.{field}")
+            self.assertIn("must be text", raised.exception.message)
+
+    def test_plan_rejects_reference_identity_drift_in_preamble_or_chunk_state(self):
+        preamble_drift = plan_v2(preamble="Keep <Picture 2> fixed.")
+        with self.assertRaises(ContinuumError) as raised:
+            validate_sequence_plan(
+                preamble_drift,
+                settings(),
+                expected_references={"<Picture 1>"},
+            )
+        self.assertEqual(raised.exception.code, "CONTINUUM_REFERENCE_IDENTITY_DRIFT")
+        self.assertEqual(raised.exception.details["unexpected"], ["<Picture 2>"])
+        self.assertEqual(raised.exception.details["allowed"], ["<Picture 1>"])
+
+        chunk_drift = plan_v2(preamble="Keep <Picture 1> fixed.")
+        chunk_drift["chunks"][1]["action"] = "Reveal <Picture 3> behind the subject."
+        with self.assertRaises(ContinuumError) as raised:
+            validate_sequence_plan(
+                chunk_drift,
+                settings(),
+                expected_references={"<Picture 1>"},
+            )
+        self.assertEqual(raised.exception.code, "CONTINUUM_REFERENCE_IDENTITY_DRIFT")
+        self.assertEqual(raised.exception.details["unexpected"], ["<Picture 3>"])
+
+    def test_plan_accepts_declared_reference_tags_across_global_and_chunk_fields(self):
+        value = plan_v2(preamble="Keep <Picture 1> as the persistent identity reference.")
+        value["global"]["continuity_anchors"] += " <Picture 1> remains the same source."
+        value["chunks"][1]["action"] = "Continue using <Picture 1> for identity."
+        validated = validate_sequence_plan(
+            value,
+            settings(),
+            expected_references={"<Picture 1>"},
+        )
+        self.assertEqual(validated["global"]["sequence_preamble"], value["global"]["sequence_preamble"])
+
+    def test_multi_chunk_preamble_rejects_opening_or_final_keyframe_tags(self):
+        value = plan_v2(preamble="Keep <Picture 2> as the final target.")
+        with self.assertRaises(ContinuumError) as raised:
+            validate_sequence_plan(
+                value,
+                settings(),
+                expected_references={"<Picture 1>", "<Picture 2>"},
+                persistent_references=set(),
+            )
+        self.assertEqual(raised.exception.code, "CONTINUUM_REFERENCE_SCOPE_DRIFT")
+        self.assertEqual(raised.exception.details["unexpected"], ["<Picture 2>"])
+
+    def test_preamble_accepts_persistent_reference_and_video_tags(self):
+        value = plan_v2(preamble="Keep <Picture 1> identity and <Video 1> motion language consistent.")
+        validated = validate_sequence_plan(
+            value,
+            settings(),
+            expected_references={"<Picture 1>", "<Video 1>"},
+            persistent_references={"<Picture 1>", "<Video 1>"},
+        )
+        self.assertEqual(validated["global"]["sequence_preamble"], value["global"]["sequence_preamble"])
+
+    def test_global_internal_fields_reject_chunk_scoped_keyframe_tags(self):
+        value = plan_v2()
+        value["global"]["continuity_anchors"] = "Keep the identity from <Picture 1> unchanged."
+        with self.assertRaises(ContinuumError) as raised:
+            validate_sequence_plan(
+                value,
+                settings(),
+                expected_references={"<Picture 1>", "<Picture 2>"},
+                persistent_references=set(),
+                chunk_reference_scopes=[
+                    {"<Picture 1>"},
+                    set(),
+                    {"<Picture 2>"},
+                ],
+            )
+        self.assertEqual(raised.exception.code, "CONTINUUM_REFERENCE_SCOPE_DRIFT")
+        self.assertEqual(raised.exception.details["scope"], "global")
+        self.assertEqual(raised.exception.details["unexpected"], ["<Picture 1>"])
+
+    def test_semantic_chunk_fields_reject_reference_outside_that_chunk_scope(self):
+        value = plan_v2()
+        value["chunks"][0]["action"] = "Reach <Picture 2> immediately."
+        with self.assertRaises(ContinuumError) as raised:
+            validate_sequence_plan(
+                value,
+                settings(),
+                expected_references={"<Picture 1>", "<Picture 2>"},
+                persistent_references=set(),
+                chunk_reference_scopes=[
+                    {"<Picture 1>"},
+                    set(),
+                    {"<Picture 2>"},
+                ],
+            )
+        self.assertEqual(raised.exception.code, "CONTINUUM_REFERENCE_SCOPE_DRIFT")
+        self.assertEqual(raised.exception.details["scope"], "chunk")
+        self.assertEqual(raised.exception.details["chunk_index"], 1)
+        self.assertEqual(raised.exception.details["unexpected"], ["<Picture 2>"])
+
+    def test_semantic_chunk_fields_accept_keyframe_tags_only_at_valid_endpoints(self):
+        value = plan_v2()
+        value["chunks"][0]["start_state"] = "Opening composition is anchored by <Picture 1>."
+        value["chunks"][2]["end_state"] = "Final composition lands on <Picture 2>."
+        validated = validate_sequence_plan(
+            value,
+            settings(),
+            expected_references={"<Picture 1>", "<Picture 2>"},
+            persistent_references=set(),
+            chunk_reference_scopes=[
+                {"<Picture 1>"},
+                set(),
+                {"<Picture 2>"},
+            ],
+        )
+        self.assertIn("<Picture 1>", validated["chunks"][0]["start_state"])
+        self.assertIn("<Picture 2>", validated["chunks"][2]["end_state"])
+
+    def test_subject_ids_are_canonicalized_from_common_model_forms(self):
+        forms = ("<Subject 1>", "<Subject A>", "Subject 1", "subject 1", "S1", "subject_1", "1", 1)
+        for raw in forms:
+            with self.subTest(raw=raw):
+                value = plan_v2()
+                value["global"]["subject_anchors"] = [
+                    {"id": raw, "meaning": "The same courier throughout the sequence."}
+                ]
+                validated = validate_sequence_plan(value, settings(), expected_references=set())
+                self.assertEqual(
+                    validated["global"]["subject_anchors"],
+                    [{"id": "<Subject 1>", "meaning": "The same courier throughout the sequence."}],
+                )
+
+    def test_alphabetic_subject_aliases_are_normalized_throughout_the_plan(self):
+        value = plan_v2()
+        value["global"]["sequence_preamble"] += " Keep <Subject A> visually stable."
+        value["global"]["continuity_anchors"] = "<Subject A> remains the same courier."
+        value["global"]["persistent_constraints"] = "Do not change <Subject A>'s coat."
+        value["global"]["subject_anchors"] = [
+            {"id": "<Subject A>", "meaning": "<Subject A> is the courier."}
+        ]
+        value["chunks"][0]["start_state"] = "<Subject A> waits by the door."
+        value["chunks"][1]["action"] = "<Subject A> crosses the room."
+        value["chunks"][2]["end_state"] = "<Subject A> stops at the window."
+        validated = validate_sequence_plan(value, settings(), expected_references=set())
+        serialized = json.dumps(validated)
+        self.assertNotIn("<Subject A>", serialized)
+        self.assertIn("<Subject 1>", serialized)
+        self.assertEqual(
+            validated["global"]["subject_anchors"],
+            [{"id": "<Subject 1>", "meaning": "<Subject 1> is the courier."}],
+        )
+
+    def test_plan_rejects_subject_tag_not_declared_in_subject_anchors(self):
+        value = plan_v2()
+        value["global"]["subject_anchors"] = []
+        value["chunks"][1]["action"] = "<Subject 1> crosses the room."
+        with self.assertRaises(ContinuumError) as raised:
+            validate_sequence_plan(value, settings(), expected_references=set())
+        self.assertEqual(raised.exception.code, "CONTINUUM_SUBJECT_IDENTITY_DRIFT")
+        self.assertEqual(raised.exception.details["unexpected"], ["<Subject 1>"])
+        self.assertEqual(raised.exception.details["planned"], [])
+
+    def test_plan_accepts_subject_tags_declared_in_subject_anchors(self):
+        value = plan_v2()
+        value["global"]["subject_anchors"] = [
+            {"id": "<Subject 1>", "meaning": "The same courier throughout the sequence."}
+        ]
+        value["global"]["sequence_preamble"] += " Keep <Subject 1> visually stable."
+        value["chunks"][1]["action"] = "<Subject 1> crosses the room."
+        validated = validate_sequence_plan(value, settings(), expected_references=set())
+        self.assertEqual(
+            validated["global"]["subject_anchors"],
+            [{"id": "<Subject 1>", "meaning": "The same courier throughout the sequence."}],
+        )
+
+    def test_duplicate_subjects_after_canonicalization_are_rejected(self):
+        value = plan_v2()
+        value["global"]["subject_anchors"] = [
+            {"id": "Subject 1", "meaning": "Courier."},
+            {"id": "1", "meaning": "Same courier again."},
+        ]
+        with self.assertRaises(ContinuumError) as raised:
+            validate_sequence_plan(value, settings(), expected_references=set())
+        self.assertIn("<Subject 1>", raised.exception.message)
+
+    def test_intentional_break_requires_an_explicit_reason(self):
+        value = plan_v2()
+        value["chunks"][1]["continuity"] = "intentional_break"
+        with self.assertRaises(ContinuumError) as raised:
+            validate_sequence_plan(value, settings(), expected_references=set())
+        self.assertEqual(raised.exception.code, "INVALID_CONTINUUM_PLAN_CONTINUITY")
+
+    def test_strict_parser_rejects_prose_wrapper_but_bounded_recovery_extracts_one_plan_object(self):
+        payload = json.dumps(plan_v2())
+        parsed = parse_sequence_plan(f"```json\n{payload}\n```", settings(), expected_references=set())
+        self.assertEqual(parsed["global"]["sequence_preamble"], plan_v2()["global"]["sequence_preamble"])
+        wrapped = f"Here is the plan:\n{payload}\nDone."
+        with self.assertRaises(ContinuumError):
+            parse_sequence_plan(wrapped, settings(), expected_references=set())
+        recovered, actions = recover_sequence_plan_contract(
+            wrapped,
+            settings(),
+            expected_references=set(),
+        )
+        self.assertEqual(recovered["global"]["sequence_preamble"], plan_v2()["global"]["sequence_preamble"])
+        self.assertEqual(actions, ["extracted_embedded_json"])
+
+    def test_bounded_recovery_synthesizes_only_from_global_semantics(self):
+        value = plan_v2()
+        value["global"]["sequence_preamble"] = ""
+        value["global"]["continuity_anchors"] = "Same courier, coat, hallway, and camera axis."
+        value["global"]["persistent_constraints"] = "Preserve the requested exclusions."
+        value["global"]["subject_anchors"] = [
+            {"id": "<Subject A>", "meaning": "<Subject A> remains the same courier."}
+        ]
+        value["chunks"][0]["action"] = "A chunk-local explosion occurs."
+        recovered, actions = recover_sequence_plan_contract(
+            json.dumps(value),
+            settings(),
+            expected_references=set(),
+        )
+        self.assertIn("synthesized_sequence_preamble", actions)
+        preamble = recovered["global"]["sequence_preamble"]
+        self.assertIn("<Subject 1> remains the same courier.", preamble)
+        self.assertIn("Same courier, coat, hallway, and camera axis.", preamble)
+        self.assertIn("Preserve the requested exclusions.", preamble)
+        self.assertNotIn("explosion", preamble.lower())
+
+    def test_bounded_recovery_defaults_optional_internal_text_and_strips_application_fields(self):
+        value = plan_v2()
+        value["global"]["sequence_preamble"] = ""
+        value["global"]["continuity_anchors"] = None
+        value["global"]["persistent_constraints"] = None
+        value["global"]["subject_anchors"] = None
+        value["global"]["reference_assignments"] = [{"tag": "<Picture 99>", "role": "wrong"}]
+        for index, chunk in enumerate(value["chunks"], start=1):
+            chunk["index"] = index
+        recovered, actions = recover_sequence_plan_contract(
+            json.dumps(value),
+            settings(),
+            expected_references=set(),
+        )
+        self.assertEqual(recovered["global"]["continuity_anchors"], "")
+        self.assertEqual(recovered["global"]["persistent_constraints"], "")
+        self.assertEqual(recovered["global"]["subject_anchors"], [])
+        self.assertEqual(recovered["global"]["reference_assignments"], [])
+        self.assertTrue(recovered["global"]["sequence_preamble"])
+        self.assertIn("defaulted_continuity_anchors", actions)
+        self.assertIn("defaulted_persistent_constraints", actions)
+        self.assertIn("defaulted_subject_anchors", actions)
+        self.assertIn("removed_reference_assignments", actions)
+        self.assertIn("removed_chunk_indexes", actions)
+
+    def test_bounded_recovery_does_not_invent_missing_chunk_semantics(self):
+        value = plan_v2()
+        value["chunks"][1]["action"] = ""
+        with self.assertRaises(ContinuumError) as raised:
+            recover_sequence_plan_contract(
+                json.dumps(value),
+                settings(),
+                expected_references=set(),
+            )
+        self.assertEqual(raised.exception.details["field"], "action")
+
+
+class CanonicalTimelineTests(unittest.TestCase):
+    def test_integer_timeline_uses_shared_preamble_and_headers_on_their_own_lines(self):
+        preamble = "Same subject and film stock remain consistent."
+        prompts = ["First section.", "Second section.", "Third section."]
+        script = serialize_timeline(preamble, prompts, 5)
+        self.assertEqual(
+            script,
+            "Same subject and film stock remain consistent.\n\n"
+            "[0-5s]\nFirst section.\n\n"
+            "[5-10s]\nSecond section.\n\n"
+            "[10-15s]\nThird section.",
+        )
+        self.assertEqual(parse_timeline_sequence(script, expected_chunks=3, chunk_seconds=5), (preamble, prompts))
+
+    def test_fractional_boundaries_are_exact_and_never_emit_float_garbage(self):
+        script = serialize_timeline("Global.", ["One.", "Two.", "Three."], 6.5)
+        self.assertIn("[0-6.5s]\n", script)
+        self.assertIn("[6.5-13s]\n", script)
+        self.assertIn("[13-19.5s]\n", script)
+        self.assertNotIn("000000", script)
+        self.assertEqual(format_timeline_seconds(0), "0")
+        self.assertEqual(format_timeline_seconds(13.0), "13")
+
+    def test_one_and_sixteen_chunk_timelines_round_trip(self):
+        for chunks in (1, 16):
+            prompts = [f"Body {index}." for index in range(1, chunks + 1)]
+            script = serialize_timeline("Global.", prompts, 4.25)
+            parsed = parse_timeline_sequence(script, expected_chunks=chunks, chunk_seconds=4.25)
+            self.assertEqual(parsed, ("Global.", prompts))
+            self.assertIn(f"[{format_timeline_seconds((chunks - 1) * 4.25)}-{format_timeline_seconds(chunks * 4.25)}s]", script)
+
+    def test_inline_or_wrong_boundaries_are_rejected_by_writer(self):
+        invalid = (
+            "[0-5s] inline body",
+            "[0-5s]\nOne.\n\n[5-11s]\nTwo.",
+            "[0 - 5s]\nOne.\n\n[5-10s]\nTwo.",
+        )
+        for value in invalid:
+            with self.subTest(value=value), self.assertRaises(ContinuumError):
+                parse_timeline_sequence(value, expected_chunks=2, chunk_seconds=5)
+
+    def test_preamble_reaches_every_resolved_prompt_once_and_hashes_cover_resolved_text(self):
+        preamble = "Persistent <Picture 1> role and lighting."
+        prompts = ["Action one.", "Action two.", "Action three."]
+        value = plan_v2(preamble=preamble)
+        result = sequence_result(settings(), value, prompts)
+        self.assertEqual(result["preamble"], preamble)
+        for index, item in enumerate(result["chunks"]):
+            expected = resolved_chunk_prompt(preamble, prompts[index])
+            self.assertEqual(item["resolved_prompt"], expected)
+            self.assertEqual(item["resolved_prompt"].count(preamble), 1)
+            self.assertEqual(item["hash"], prompt_hash(expected))
+
+    def test_empty_preamble_is_only_supported_for_strict_legacy_migration(self):
+        legacy = serialize_chunk_prompts(["One.", "Two."])
+        self.assertEqual(parse_chunk_prompts(legacy, expected_chunks=2), ["One.", "Two."])
+        migrated = serialize_timeline("", ["One.", "Two."], 5)
+        self.assertEqual(migrated, "[0-5s]\nOne.\n\n[5-10s]\nTwo.")
+
+
+class ContinuumAssemblyTests(unittest.TestCase):
+    def test_continuum_plan_requires_authoritative_downstream_inventory(self):
+        request = body()
+        request.pop("downstream_reference_inventory")
+        with self.assertRaises(ContinuumError) as raised:
+            assemble_continuum_plan_request(request)
+        self.assertEqual(raised.exception.code, "INVALID_DOWNSTREAM_REFERENCE_INVENTORY")
+        self.assertEqual(
+            raised.exception.details["field"],
+            "downstream_reference_inventory",
+        )
+
+    def test_declared_only_reference_is_allowed_without_model_visible_media(self):
+        request = body(
+            "Reference",
+            brief="Use <Picture 1> for the subject identity and <Picture 2> for the environment.",
+            inventory=downstream_inventory(2),
+        )
+        with patch("backend.assembly.STORE.manifest", return_value=manifest("Reference", [])):
+            assembled = assemble_continuum_plan_request(request)
+        self.assertEqual(assembled["media_inputs"], [])
+        self.assertEqual(
+            [item["tag"] for item in assembled["input"]["downstream_reference_inventory"]["items"]],
+            ["<Picture 1>", "<Picture 2>"],
+        )
+        user = assembled["messages"][-1]["content"]
+        self.assertIn(
+            "<Picture 1>: downstream reference_image conditioning via reference_image_1 (visible to planner: no)",
+            user,
+        )
+        self.assertIn("do not invent unseen content", user)
+
+    def test_unbound_prompt_writer_image_is_described_as_analysis_media(self):
+        request = body(
+            "Reference",
+            brief="Use <Picture 1> for identity.",
+            inventory=downstream_inventory(1),
+        )
+        with patch("backend.assembly.STORE.manifest", return_value=manifest("Reference", [picture(1)])):
+            assembled = assemble_continuum_plan_request(request)
+        self.assertEqual(
+            assembled["media_inputs"][0]["reference"],
+            "Analysis image 1 (no downstream public reference identity)",
+        )
+        self.assertIn(
+            "<Picture 1>: downstream reference_image conditioning via reference_image_1 (visible to planner: no)",
+            assembled["messages"][-1]["content"],
+        )
+
+    def test_explicit_model_asset_binding_exposes_the_same_pixels_as_downstream_picture(self):
+        inventory = downstream_inventory(1)
+        inventory["items"][0].update({
+            "visible_to_model": True,
+            "model_asset_id": "picture-1",
+        })
+        request = body(
+            "Reference",
+            brief="Use <Picture 1> for identity.",
+            inventory=inventory,
+        )
+        with patch("backend.assembly.STORE.manifest", return_value=manifest("Reference", [picture(1)])):
+            assembled = assemble_continuum_plan_request(request)
+        self.assertEqual(assembled["media_inputs"][0]["reference"], "<Picture 1>")
+        self.assertIn(
+            "<Picture 1>: downstream reference_image conditioning via reference_image_1 (visible to planner: yes)",
+            assembled["messages"][-1]["content"],
+        )
+
+    def test_undeclared_reference_fails_before_plan_inference(self):
+        request = body(
+            "Reference",
+            brief="Use <Picture 3> for the background.",
+            inventory=downstream_inventory(2),
+        )
+        with patch("backend.assembly.STORE.manifest", return_value=manifest("Reference", [])):
+            with self.assertRaises(AssemblyError) as raised:
+                assemble_continuum_plan_request(request)
+        self.assertEqual(raised.exception.code, "REFERENCE_NOT_DECLARED")
+        self.assertEqual(raised.exception.details["reference"], "<Picture 3>")
+
+    def test_planner_contract_uses_semantic_chunks_and_production_preamble(self):
+        with patch("backend.assembly.STORE.manifest", return_value=manifest()):
+            assembled = assemble_continuum_plan_request(body())
+        system = assembled["messages"][0]["content"]
+        user = assembled["messages"][1]["content"]
+        schema = user.split("Schema:\n", 1)[1]
+        self.assertIn("global.sequence_preamble", system)
+        self.assertIn("application owns chunk count, time boundaries", system)
+        self.assertNotIn('"index"', schema)
+        self.assertNotIn('"reference_assignments"', schema)
+        self.assertIn('"sequence_preamble"', schema)
+
+    def test_planner_receives_keyframe_video_and_audio_topology_without_invented_tags(self):
+        request = body(
+            "Reference",
+            brief="Keep the opening and closing keyframes, use <Picture 1> for identity, follow the Video Reference motion, and preserve Driving Audio.",
+            inventory=downstream_inventory(
+                1,
+                first_frame=True,
+                last_frame=True,
+                video_reference=True,
+                driving_audio=True,
+            ),
+        )
+        with patch("backend.assembly.STORE.manifest", return_value=manifest("Reference", [])):
+            assembled = assemble_continuum_plan_request(request)
+        user = assembled["messages"][-1]["content"]
+        self.assertIn("<Picture 1>: downstream reference_image conditioning", user)
+        self.assertIn("First Frame keyframe: downstream first_frame conditioning", user)
+        self.assertIn("Last Frame keyframe: downstream last_frame conditioning", user)
+        self.assertIn("<Video 1>: downstream video_reference conditioning", user)
+        self.assertIn("Driving Audio: downstream driving_audio conditioning", user)
+        self.assertIn("Every inventory entry with an explicit public tag owns that exact H3 prompt identity", user)
+        self.assertIn("tagged First Frame is opening-chunk-only", user)
+
+    def test_plan_repair_audits_the_complete_contract_and_keeps_application_owned_fields_out(self):
+        error = ContinuumError("INVALID_CONTINUUM_PLAN", "Bad shape.", {"field": "chunks"})
+        with patch("backend.assembly.STORE.manifest", return_value=manifest()):
+            assembled = assemble_continuum_plan_repair_request(body(), "{bad", error)
+        system = assembled["messages"][0]["content"]
+        self.assertIn("global.sequence_preamble is the common Continuum prompt text", system)
+        self.assertIn("Driving Audio is persistent conditioning", system)
+        self.assertIn("first validation failure", system)
+        self.assertIn("repair every contract violation", system)
+        self.assertIn("whole object to validate", system)
+        self.assertIn("required non-empty global.sequence_preamble", system)
+        self.assertIn("canonical positive numeric IDs such as <Subject 1>", system)
+        self.assertIn("never alphabetic IDs such as <Subject A>", system)
+        self.assertIn("Do not add application-owned chunk indexes", system)
+        user = assembled["messages"][1]["content"]
+        self.assertIn("First validation error: Bad shape.", user)
+        self.assertIn("Repair the whole object, not only that field.", user)
+
+    def test_generated_chunk_rejects_subject_when_plan_declares_no_subjects(self):
+        request = body()
+        no_subject_plan = plan_v2()
+        no_subject_plan["global"]["subject_anchors"] = []
+        normalized_plan = validate_sequence_plan(
+            no_subject_plan,
+            settings(),
+            expected_references=set(),
+        )
+        with patch("backend.assembly.STORE.manifest", return_value=manifest()):
+            assembled = assemble_continuum_chunk_request(
+                request,
+                normalized_plan,
+                1,
+                previous_prompt=None,
+            )
+        with self.assertRaises(ContinuumError) as raised:
+            validate_generated_chunk("<Subject 1> enters the room.", assembled)
+        self.assertEqual(raised.exception.code, "CONTINUUM_SUBJECT_IDENTITY_DRIFT")
+        self.assertEqual(raised.exception.details["unexpected"], ["<Subject 1>"])
+        self.assertEqual(raised.exception.details["planned"], [])
+
+    def test_generated_chunk_allows_declared_unseen_tags_and_rejects_undeclared_tags(self):
+        request = body(
+            "Reference",
+            brief="Use <Picture 1>.",
+            inventory=downstream_inventory(1),
+        )
+        with patch("backend.assembly.STORE.manifest", return_value=manifest("Reference", [])):
+            plan_request = assemble_continuum_plan_request(request)
+            normalized_plan = validate_sequence_plan(
+                plan_v2(),
+                settings(),
+                expected_references={"<Picture 1>"},
+            )
+            assembled = assemble_continuum_chunk_request(
+                request,
+                normalized_plan,
+                1,
+                previous_prompt=None,
+            )
+        self.assertEqual(validate_generated_chunk("Use <Picture 1>.", assembled), "Use <Picture 1>.")
+        with self.assertRaises(ContinuumError) as raised:
+            validate_generated_chunk("Use <Picture 2>.", assembled)
+        self.assertEqual(raised.exception.code, "CONTINUUM_REFERENCE_IDENTITY_DRIFT")
+
+    def test_chunk_format_validator_rejects_repeated_preamble_and_standalone_wrappers(self):
+        preamble = "Stable identity and camera language."
+        bad_cases = {
+            "repeated preamble": preamble + "\n\nContinue walking.",
+            "base field": "integrated_multimodal_description: Continue walking.",
+            "reference field": "subject_definitions: <Subject 1> is the courier.",
+            "shot wrapper": "[Shot 1] Continue walking.",
+            "alignment": "How the reference pictures align with the target video: Picture 1 is first.",
+            "fence": "\x60\x60\x60\nContinue walking.\n\x60\x60\x60",
+        }
+        for label, prompt in bad_cases.items():
+            with self.subTest(label=label):
+                self.assertTrue(
+                    continuum_chunk_format_violations(
+                        prompt,
+                        preamble=preamble,
+                    )
+                )
+        self.assertEqual(
+            continuum_chunk_format_violations(
+                "Continue walking as the camera tracks beside the courier.",
+                preamble=preamble,
+            ),
+            [],
+        )
+
+    def test_generated_chunk_rejects_repeated_preamble_before_serialization(self):
+        normalized_plan = validate_sequence_plan(
+            plan_v2(preamble="Stable identity and camera language."),
+            settings(),
+            expected_references=set(),
+        )
+        with patch("backend.assembly.STORE.manifest", return_value=manifest()):
+            assembled = assemble_continuum_chunk_request(
+                body(),
+                normalized_plan,
+                1,
+                previous_prompt=None,
+            )
+        with self.assertRaises(ContinuumError) as raised:
+            validate_generated_chunk(
+                "Stable identity and camera language.\n\nContinue walking.",
+                assembled,
+            )
+        self.assertEqual(raised.exception.code, "INVALID_CONTINUUM_CHUNK_FORMAT")
+        self.assertIn(
+            "repeated shared sequence preamble",
+            raised.exception.details["violations"],
+        )
+
+    def test_continuum_chunk_writer_uses_dedicated_contract_not_standalone_mode_wrapper(self):
+        request = body(
+            "FL2VA",
+            brief="Start from <Picture 1> and end at <Picture 2>.",
+            inventory=downstream_inventory(0, first_frame=True, last_frame=True),
+        )
+        normalized_plan = validate_sequence_plan(
+            plan_v2(),
+            settings(),
+            expected_references={"<Picture 1>", "<Picture 2>"},
+            persistent_references=set(),
+        )
+        with patch("backend.assembly.STORE.manifest", return_value=manifest("FL2VA", [])):
+            assembled = assemble_continuum_chunk_request(
+                request,
+                normalized_plan,
+                1,
+                previous_prompt=None,
+            )
+        self.assertEqual(assembled["guide"]["id"], "h3-continuum-chunk-v2")
+        self.assertEqual(assembled["messages"][0]["name"], "h3_continuum_chunk_writer")
+        system = assembled["messages"][0]["content"]
+        self.assertIn("not a standalone T2VA/I2VA/FL2VA/L2VA/Reference request", system)
+        self.assertIn("do not write absolute sequence timestamps inside a chunk body", system)
+        self.assertIn("stable sequence-wide IDs such as (S1), (S2)", system)
+        self.assertIn("<d>[Language] ...</d>", system)
+        self.assertIn("Treat every explicitly assigned reference role as exclusive", system)
+        self.assertIn("Driving Audio owns no <Audio N> tag", system)
+        self.assertNotIn("How the reference pictures align", assembled["messages"][-1]["content"])
+        self.assertEqual(assembled["input"]["continuum_chunk_allowed_references"], ["<Picture 1>"])
+
+    def test_fl2va_keyframe_tags_are_scoped_to_opening_and_final_chunks(self):
+        request = body(
+            "FL2VA",
+            brief="Start from <Picture 1> and eventually reach <Picture 2>.",
+            inventory=downstream_inventory(0, first_frame=True, last_frame=True),
+        )
+        normalized_plan = validate_sequence_plan(
+            plan_v2(),
+            settings(),
+            expected_references={"<Picture 1>", "<Picture 2>"},
+            persistent_references=set(),
+        )
+        with patch("backend.assembly.STORE.manifest", return_value=manifest("FL2VA", [])):
+            chunk1 = assemble_continuum_chunk_request(request, normalized_plan, 1, previous_prompt=None)
+            chunk2 = assemble_continuum_chunk_request(request, normalized_plan, 2, previous_prompt="Opening.")
+            chunk3 = assemble_continuum_chunk_request(request, normalized_plan, 3, previous_prompt="Middle.")
+
+        self.assertEqual(chunk1["input"]["continuum_chunk_allowed_references"], ["<Picture 1>"])
+        self.assertEqual(chunk2["input"]["continuum_chunk_allowed_references"], [])
+        self.assertEqual(chunk3["input"]["continuum_chunk_allowed_references"], ["<Picture 2>"])
+        self.assertEqual(validate_generated_chunk("Open from <Picture 1>.", chunk1), "Open from <Picture 1>.")
+        self.assertEqual(validate_generated_chunk("Continue the same action.", chunk2), "Continue the same action.")
+        self.assertEqual(validate_generated_chunk("Land on <Picture 2>.", chunk3), "Land on <Picture 2>.")
+        for bad_prompt, assembled in (
+            ("Reach <Picture 2> immediately.", chunk1),
+            ("Reset to <Picture 1>.", chunk2),
+            ("Reset to <Picture 1>.", chunk3),
+        ):
+            with self.subTest(prompt=bad_prompt), self.assertRaises(ContinuumError) as raised:
+                validate_generated_chunk(bad_prompt, assembled)
+            self.assertEqual(raised.exception.code, "CONTINUUM_REFERENCE_IDENTITY_DRIFT")
+
+    def test_persistent_reference_image_and_video_tags_remain_available_in_middle_chunk(self):
+        request = body(
+            "Reference",
+            brief="Keep <Picture 1> identity and <Video 1> motion language.",
+            inventory=downstream_inventory(
+                1,
+                first_frame=True,
+                last_frame=True,
+                video_reference=True,
+            ),
+        )
+        normalized_plan = validate_sequence_plan(
+            plan_v2(preamble="Keep <Picture 1> identity and <Video 1> motion language consistent."),
+            settings(),
+            expected_references={"<Picture 1>", "<Video 1>"},
+            persistent_references={"<Picture 1>", "<Video 1>"},
+        )
+        with patch("backend.assembly.STORE.manifest", return_value=manifest("Reference", [])):
+            middle = assemble_continuum_chunk_request(
+                request,
+                normalized_plan,
+                2,
+                previous_prompt="Opening.",
+            )
+        self.assertEqual(
+            middle["input"]["continuum_chunk_allowed_references"],
+            ["<Picture 1>", "<Video 1>"],
+        )
+        self.assertEqual(
+            validate_generated_chunk("Continue <Picture 1> using <Video 1> motion.", middle),
+            "Continue <Picture 1> using <Video 1> motion.",
+        )
+
+    def test_hybrid_keyframes_do_not_expand_picture_inventory_but_video_reference_is_public(self):
+        request = body(
+            "Reference",
+            brief="Use <Picture 1> and <Video 1>.",
+            inventory=downstream_inventory(
+                1,
+                first_frame=True,
+                last_frame=True,
+                video_reference=True,
+                driving_audio=True,
+            ),
+        )
+        with patch("backend.assembly.STORE.manifest", return_value=manifest("Reference", [])):
+            assembled = assemble_continuum_plan_request(request)
+        self.assertEqual(
+            [item["tag"] for item in assembled["input"]["downstream_reference_inventory"]["items"] if item.get("tag")],
+            ["<Picture 1>", "<Video 1>"],
+        )
+
+    def test_fl2va_keyframes_are_valid_public_picture_one_and_two_without_reference_images(self):
+        request = body(
+            "FL2VA",
+            brief="Start from <Picture 1> and reach <Picture 2>.",
+            inventory=downstream_inventory(0, first_frame=True, last_frame=True),
+        )
+        with patch("backend.assembly.STORE.manifest", return_value=manifest("FL2VA", [])):
+            assembled = assemble_continuum_plan_request(request)
+        self.assertEqual(
+            effective_reference_tags(assembled["input"], continuum=True),
+            {"<Picture 1>", "<Picture 2>"},
+        )
+
+
+class SequenceReferenceScopeTests(unittest.TestCase):
+    def test_manual_keyframe_scope_rejects_middle_chunk_and_global_final_tag(self):
+        request_input = {
+            "downstream_reference_inventory": downstream_inventory(
+                0,
+                first_frame=True,
+                last_frame=True,
+                video_reference=True,
+            ),
+            "media_manifest": manifest("FL2VA", []),
+        }
+        with self.assertRaises(ContinuumError) as raised:
+            validate_sequence_reference_scope(
+                request_input,
+                preamble="Stable scene.",
+                prompts=[
+                    "Open from <Picture 1>.",
+                    "Reset to <Picture 1>.",
+                    "Finish on <Picture 2>.",
+                ],
+                chunks=3,
+            )
+        self.assertEqual(raised.exception.code, "CONTINUUM_REFERENCE_SCOPE_DRIFT")
+        self.assertEqual(raised.exception.details["chunk_index"], 2)
+
+        with self.assertRaises(ContinuumError) as raised:
+            validate_sequence_reference_scope(
+                request_input,
+                preamble="Keep <Picture 2> fixed.",
+                prompts=["Open.", "Continue.", "Finish."],
+                chunks=3,
+            )
+        self.assertEqual(raised.exception.code, "CONTINUUM_REFERENCE_SCOPE_DRIFT")
+        self.assertEqual(raised.exception.details["scope"], "global")
+
+    def test_reference_audio_is_persistent_in_preamble_and_every_chunk(self):
+        request_input = {
+            "downstream_reference_inventory": downstream_inventory(
+                0,
+                reference_audio=True,
+                driving_audio=True,
+            ),
+            "media_manifest": manifest("Reference", []),
+        }
+        validate_sequence_reference_scope(
+            request_input,
+            preamble="Keep <Audio 1> as the persistent reference-audio identity.",
+            prompts=[
+                "Open with <Audio 1> conditioning.",
+                "Continue with <Audio 1> conditioning.",
+                "Finish with <Audio 1> conditioning.",
+            ],
+            chunks=3,
+        )
+
+    def test_manual_hybrid_persistent_reference_and_video_are_valid_in_middle_chunk(self):
+        request_input = {
+            "downstream_reference_inventory": downstream_inventory(
+                1,
+                first_frame=True,
+                last_frame=True,
+                video_reference=True,
+            ),
+            "media_manifest": manifest("Reference", []),
+        }
+        validate_sequence_reference_scope(
+            request_input,
+            preamble="Keep <Picture 1> identity and <Video 1> motion language stable.",
+            prompts=[
+                "Open.",
+                "Continue <Picture 1> with <Video 1>.",
+                "Finish.",
+            ],
+            chunks=3,
+        )
+
+
+class ContinuumRefinementTests(unittest.TestCase):
+    def test_chunk_local_refinement_keeps_preamble_and_untouched_hashes_identical(self):
+        preamble = "Stable identity, wardrobe, environment, lens language, and room tone."
+        prompts = ["Chunk one.", "Chunk two.", "Chunk three."]
+        value = plan_v2(preamble=preamble)
+        original = sequence_result(settings(), value, prompts)
+        request = body()
+        request.update({
+            "current_prompt": original["prompt"],
+            "instruction": "Slow the hand movement only in the second span.",
+        })
+        request["continuum"].update({"chunk_index": 2, "plan": original["plan"]})
+
+        with patch("backend.assembly.STORE.manifest", return_value=manifest()):
+            assembled, sequence_state, index, saved_plan = assemble_continuum_refinement(request)
+        self.assertEqual(sequence_state, {
+            "preamble": preamble,
+            "prompts": prompts,
+            "downstream_reference_inventory": downstream_inventory(0),
+        })
+        self.assertEqual(index, 2)
+        self.assertIn("Current selected chunk body:\nChunk two.", assembled["messages"][-1]["content"])
+        self.assertIn("Following unchanged chunk-local prompt for boundary compatibility:\nChunk three.", assembled["messages"][-1]["content"])
+        self.assertIn("Return only the complete replacement body for this logical span.", assembled["messages"][-1]["content"])
+        self.assertIn("Do not repeat the shared preamble.", assembled["messages"][-1]["content"])
+
+        updated = apply_continuum_refinement(
+            "Refined chunk two.",
+            assembled,
+            sequence_state,
+            index,
+            saved_plan,
+        )
+        self.assertEqual(updated["preamble"], preamble)
+        self.assertEqual(updated["chunks"][0]["resolved_prompt"], original["chunks"][0]["resolved_prompt"])
+        self.assertEqual(updated["chunks"][2]["resolved_prompt"], original["chunks"][2]["resolved_prompt"])
+        self.assertEqual(updated["chunks"][0]["hash"], original["chunks"][0]["hash"])
+        self.assertEqual(updated["chunks"][2]["hash"], original["chunks"][2]["hash"])
+        self.assertNotEqual(updated["chunks"][1]["hash"], original["chunks"][1]["hash"])
+
+    def test_sequence_result_snapshots_authoritative_downstream_inventory(self):
+        inventory = downstream_inventory(1, first_frame=True)
+        inventory["items"][0].update({
+            "source_node_id": 41,
+            "source_node_class": "LoadImage",
+            "source_output_name": "IMAGE",
+            "source_slot": 0,
+        })
+        result = sequence_result(
+            settings(),
+            plan_v2(),
+            ["One.", "Two.", "Three."],
+            downstream_reference_inventory=inventory,
+        )
+        self.assertEqual(result["downstream_reference_inventory"], inventory)
+
+    def test_refinement_rejects_same_public_tag_rewired_to_different_source(self):
+        saved_inventory = downstream_inventory(1)
+        saved_inventory["items"][0].update({
+            "source_node_id": 41,
+            "source_node_class": "LoadImage",
+            "source_output_name": "IMAGE",
+            "source_slot": 0,
+        })
+        active_inventory = downstream_inventory(1)
+        active_inventory["items"][0].update({
+            "source_node_id": 99,
+            "source_node_class": "LoadImage",
+            "source_output_name": "IMAGE",
+            "source_slot": 0,
+        })
+        original = sequence_result(
+            settings(),
+            plan_v2(),
+            ["One.", "Two.", "Three."],
+            downstream_reference_inventory=saved_inventory,
+        )
+        request = body(
+            "Reference",
+            brief="Keep <Picture 1> identity stable.",
+            inventory=active_inventory,
+        )
+        request.update({
+            "current_prompt": original["prompt"],
+            "instruction": "Slow Chunk 2.",
+        })
+        request["continuum"].update({
+            "chunk_index": 2,
+            "plan": original["plan"],
+            "downstream_reference_inventory": original["downstream_reference_inventory"],
+        })
+        with patch("backend.assembly.STORE.manifest", return_value=manifest("Reference", [])):
+            with self.assertRaises(ContinuumError) as raised:
+                assemble_continuum_refinement(request)
+        self.assertEqual(raised.exception.code, "CONTINUUM_REFERENCE_SOURCE_DRIFT")
+        self.assertEqual(
+            raised.exception.details["saved_inventory"]["items"][0]["source_node_id"],
+            41,
+        )
+        self.assertEqual(
+            raised.exception.details["active_inventory"]["items"][0]["source_node_id"],
+            99,
+        )
+
+    def test_legacy_refinement_without_inventory_snapshot_adopts_active_inventory(self):
+        inventory = downstream_inventory(1)
+        inventory["items"][0].update({
+            "source_node_id": 41,
+            "source_node_class": "LoadImage",
+            "source_output_name": "IMAGE",
+            "source_slot": 0,
+        })
+        original = sequence_result(settings(), plan_v2(), ["One.", "Two.", "Three."])
+        request = body(
+            "Reference",
+            brief="Keep <Picture 1> identity stable.",
+            inventory=inventory,
+        )
+        request.update({
+            "current_prompt": original["prompt"],
+            "instruction": "Slow Chunk 2.",
+        })
+        request["continuum"].update({
+            "chunk_index": 2,
+            "plan": original["plan"],
+        })
+        with patch("backend.assembly.STORE.manifest", return_value=manifest("Reference", [])):
+            assembled, state, index, saved_plan = assemble_continuum_refinement(request)
+        self.assertEqual(state["downstream_reference_inventory"], inventory)
+        migrated = apply_continuum_refinement(
+            "Changed two.",
+            assembled,
+            state,
+            index,
+            saved_plan,
+        )
+        self.assertEqual(migrated["downstream_reference_inventory"], inventory)
+
+    def test_refinement_rejects_manually_edited_middle_chunk_using_opening_keyframe_tag(self):
+        inventory = downstream_inventory(0, first_frame=True, last_frame=True)
+        scoped_plan = plan_v2()
+        scoped_plan["chunks"][0]["start_state"] = "Opening anchored by <Picture 1>."
+        scoped_plan["chunks"][2]["end_state"] = "Ending lands on <Picture 2>."
+        normalized = validate_sequence_plan(
+            scoped_plan,
+            settings(),
+            expected_references={"<Picture 1>", "<Picture 2>"},
+            persistent_references=set(),
+            chunk_reference_scopes=[
+                {"<Picture 1>"},
+                set(),
+                {"<Picture 2>"},
+            ],
+        )
+        original = sequence_result(
+            settings(),
+            normalized,
+            ["Open from <Picture 1>.", "Continue.", "Land on <Picture 2>."],
+        )
+        request = body(
+            "FL2VA",
+            brief="Start from <Picture 1> and eventually reach <Picture 2>.",
+            inventory=inventory,
+        )
+        request.update({
+            "current_prompt": original["prompt"].replace(
+                "[5-10s]\nContinue.",
+                "[5-10s]\nReset to <Picture 1>.",
+            ),
+            "instruction": "Slow Chunk 2.",
+        })
+        request["continuum"].update({"chunk_index": 2, "plan": normalized})
+        with patch("backend.assembly.STORE.manifest", return_value=manifest("FL2VA", [])):
+            with self.assertRaises(ContinuumError) as raised:
+                assemble_continuum_refinement(request)
+        self.assertEqual(raised.exception.code, "CONTINUUM_REFERENCE_SCOPE_DRIFT")
+        self.assertEqual(raised.exception.details["chunk_index"], 2)
+
+    def test_editing_shared_preamble_requires_global_regeneration(self):
+        value = plan_v2(preamble="Original global.")
+        original = sequence_result(settings(), value, ["One.", "Two.", "Three."])
+        request = body()
+        request["current_prompt"] = original["prompt"].replace("Original global.", "Changed global.")
+        request["instruction"] = "Change chunk two."
+        request["continuum"].update({"chunk_index": 2, "plan": original["plan"]})
+        with patch("backend.assembly.STORE.manifest", return_value=manifest()):
+            with self.assertRaises(ContinuumError) as raised:
+                assemble_continuum_refinement(request)
+        self.assertIn("sequence-wide plan", raised.exception.message)
+
+    def test_schema_v2_refinement_rejects_legacy_chunk_text_instead_of_dropping_preamble(self):
+        request = body()
+        request["current_prompt"] = serialize_chunk_prompts(["One.", "Two.", "Three."])
+        request["instruction"] = "Change chunk two."
+        request["continuum"].update({
+            "schema_version": 2,
+            "chunk_index": 2,
+            "plan": plan_v2(preamble="Global."),
+        })
+        with patch("backend.assembly.STORE.manifest", return_value=manifest()):
+            with self.assertRaises(ContinuumError) as raised:
+                assemble_continuum_refinement(request)
+        self.assertEqual(raised.exception.code, "INVALID_CONTINUUM_SEQUENCE")
+
+    def test_legacy_saved_draft_migrates_without_reinterpreting_arbitrary_text(self):
+        prompts = ["One.", "Two.", "Three."]
+        request = body()
+        request["current_prompt"] = serialize_chunk_prompts(prompts)
+        request["instruction"] = "Change chunk two."
+        request["continuum"].update({
+            "schema_version": 1,
+            "chunk_index": 2,
+            "plan": plan_v1(),
+        })
+        with patch("backend.assembly.STORE.manifest", return_value=manifest()):
+            assembled, state, index, saved_plan = assemble_continuum_refinement(request)
+        self.assertEqual(state, {
+            "preamble": "",
+            "prompts": prompts,
+            "downstream_reference_inventory": downstream_inventory(0),
+        })
+        migrated = apply_continuum_refinement("Changed two.", assembled, state, index, saved_plan)
+        self.assertEqual(
+            migrated["prompt"],
+            "[0-5s]\nOne.\n\n[5-10s]\nChanged two.\n\n[10-15s]\nThree.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_continuum_cross_repo.py
+++ b/tests/test_continuum_cross_repo.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import sys
+import types
+import unittest
+
+from backend.continuum import prompt_hash, resolved_chunk_prompt, serialize_timeline
+
+
+def _load_continuum_prompts(source_root: Path):
+    package_name = "_h3_continuum_contract"
+    package = types.ModuleType(package_name)
+    package.__path__ = [str(source_root)]
+    sys.modules[package_name] = package
+
+    v2_name = f"{package_name}.v2"
+    v2_package = types.ModuleType(v2_name)
+    v2_package.__path__ = [str(source_root / "v2")]
+    sys.modules[v2_name] = v2_package
+
+    for module_name, path in (
+        (f"{package_name}.constants", source_root / "constants.py"),
+        (f"{package_name}.version", source_root / "version.py"),
+        (f"{v2_name}.prompts", source_root / "v2" / "prompts.py"),
+    ):
+        spec = importlib.util.spec_from_file_location(module_name, path)
+        if spec is None or spec.loader is None:
+            raise RuntimeError(f"Could not load {path}")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+    return sys.modules[f"{v2_name}.prompts"]
+
+
+@unittest.skipUnless(os.environ.get("H3_CONTINUUM_SOURCE"), "H3_CONTINUUM_SOURCE is required for cross-repo contract CI")
+class ContinuumCrossRepositoryContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        root = Path(os.environ["H3_CONTINUUM_SOURCE"]).resolve()
+        cls.source_root = root
+        cls.prompts = _load_continuum_prompts(root)
+
+    def assert_writer_matches_continuum(self, preamble, bodies, chunk_seconds):
+        script = serialize_timeline(preamble, bodies, chunk_seconds)
+        plan = self.prompts.make_prompt_plan(
+            mode="Timeline",
+            script=script,
+            chunks=len(bodies),
+            chunk_seconds=chunk_seconds,
+        )
+        expected = [resolved_chunk_prompt(preamble, body) for body in bodies]
+        self.assertEqual(plan["mode"], self.prompts.PROMPT_MODE_TIMELINE)
+        self.assertNotIn("used Fixed prompt fallback", plan.get("notes", []))
+        self.assertEqual(plan["prompts"], expected)
+        self.assertEqual(plan["hashes"], [prompt_hash(prompt) for prompt in expected])
+        return script, plan
+
+    def test_current_public_sampler_family_matches_frontend_discovery(self):
+        constants_source = (self.source_root / "constants.py").read_text(encoding="utf-8")
+        base_source = (self.source_root / "v3" / "nodes.py").read_text(encoding="utf-8")
+        driving_source = (self.source_root / "v3" / "driving_nodes.py").read_text(encoding="utf-8")
+        root_source = (self.source_root / "nodes.py").read_text(encoding="utf-8")
+
+        self.assertIn("CHUNK_SECONDS_MIN = 4.0", constants_source)
+        self.assertIn("CHUNK_SECONDS_MAX = 30.0", constants_source)
+        self.assertIn('"sequence_prompt": (', base_source)
+        self.assertIn('"first_frame": (', base_source)
+        self.assertIn('"last_frame": ("IMAGE",)', base_source)
+        for index in range(1, 4):
+            self.assertIn(f'"reference_image_{index}": ("IMAGE",)', base_source)
+
+        # Official upstream exposes three persistent image-reference sockets.
+        # Writer discovery remains tolerant of extension facades with additional
+        # sockets, but the reviewed upstream contract itself is exactly 1–3.
+        self.assertNotIn("for index in range(4, 9):", driving_source)
+        self.assertIn('optional["reference_video_1"] = (', driving_source)
+        self.assertIn('optional["driving_audio"] = (', driving_source)
+        self.assertIn('optional["reference_audio_1"] = (', driving_source)
+        self.assertIn('optional["guide"] = (', driving_source)
+        self.assertIn("class H3ContinuumSamplerV35(H3ContinuumSamplerV34)", driving_source)
+        self.assertIn("class H3ContinuumSamplerV36(H3ContinuumSamplerV35)", driving_source)
+        self.assertIn("class H3ContinuumSamplerV37(H3ContinuumSamplerV36)", driving_source)
+        for node_id in (
+            "H3ContinuumSamplerV34",
+            "H3ContinuumSamplerV35",
+            "H3ContinuumSamplerV36",
+            "H3ContinuumSamplerV37",
+        ):
+            self.assertIn(f'"{node_id}"', root_source)
+
+    def test_integer_timeline_preamble_and_hashes_match_real_continuum_parser(self):
+        script, plan = self.assert_writer_matches_continuum(
+            "Stable subject identity, wardrobe, environment, film treatment, and room tone persist.",
+            ["The subject enters frame.", "The subject crosses the room.", "The subject reaches the window."],
+            5,
+        )
+        self.assertIn("[0-5s]\n", script)
+        self.assertEqual(len(plan["prompts"]), 3)
+
+    def test_fractional_timeline_boundaries_match_real_continuum_parser(self):
+        script, _plan = self.assert_writer_matches_continuum(
+            "Global continuity.",
+            ["One.", "Two.", "Three."],
+            6.5,
+        )
+        self.assertIn("[0-6.5s]\n", script)
+        self.assertIn("[6.5-13s]\n", script)
+        self.assertIn("[13-19.5s]\n", script)
+
+    def test_local_body_edit_preserves_real_continuum_prefix_hashes(self):
+        preamble = "Persistent identity and camera language."
+        bodies = ["One.", "Two.", "Three."]
+        _script, before = self.assert_writer_matches_continuum(preamble, bodies, 5)
+        changed = list(bodies)
+        changed[2] = "Changed three."
+        _script, after = self.assert_writer_matches_continuum(preamble, changed, 5)
+        self.assertEqual(after["hashes"][:2], before["hashes"][:2])
+        self.assertNotEqual(after["hashes"][2], before["hashes"][2])
+
+    def test_preamble_edit_changes_all_real_continuum_hashes(self):
+        bodies = ["One.", "Two.", "Three."]
+        _script, before = self.assert_writer_matches_continuum("Global A.", bodies, 5)
+        _script, after = self.assert_writer_matches_continuum("Global B.", bodies, 5)
+        self.assertTrue(all(a != b for a, b in zip(before["hashes"], after["hashes"], strict=True)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_continuum_image_conveyor.mjs
+++ b/tests/test_continuum_image_conveyor.mjs
@@ -1,0 +1,547 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const continuumSource = await readFile(new URL("../web/continuum.js", import.meta.url), "utf8");
+const continuumEncoded = Buffer.from(continuumSource).toString("base64");
+const {
+  bindContinuumReferenceMedia,
+  discoverContinuumReferenceInventory,
+  discoverContinuumWorkflowImageMedia,
+  sameContinuumReferenceInventory,
+  sameContinuumWorkflowSourceInventory,
+  validateContinuumModeTopology,
+} = await import(`data:text/javascript;base64,${continuumEncoded}`);
+
+const OUTPUT_NAMES = [
+  "image",
+  "mask",
+  "path",
+  "index",
+  "remaining_pending",
+  "source_path",
+  "ref_image_1",
+  "ref_image_2",
+  "ref_image_3",
+  "ref_image_4",
+  "ref_image_5",
+  "ref_image_6",
+  "ref_image_7",
+  "ref_image_8",
+  "last_frame",
+];
+
+function samplerNode(id = 100) {
+  return {
+    id,
+    type: "H3ContinuumSamplerV34",
+    inputs: [
+      { name: "sequence_prompt", type: "STRING", link: null },
+      { name: "first_frame", type: "IMAGE", link: null },
+      { name: "last_frame", type: "IMAGE", link: null },
+      ...Array.from({ length: 8 }, (_, index) => ({
+        name: `reference_image_${index + 1}`,
+        type: "IMAGE",
+        link: null,
+      })),
+      { name: "reference_video_1", type: "IMAGE", link: null },
+      { name: "driving_audio", type: "AUDIO", link: null },
+    ],
+    outputs: [],
+    widgets: [
+      { name: "prompt_mode", value: "Timeline" },
+      { name: "chunks", value: 3 },
+      { name: "chunk_seconds", value: 5 },
+    ],
+  };
+}
+
+function conveyorNode({
+  id = 10,
+  type = "ImageConveyor",
+  outputMode = "persistent_refs",
+  imagesPerExecution = 1,
+  referenceSlots = Array(8).fill(null),
+  state = {},
+  properties = {},
+} = {}) {
+  const stateJson = JSON.stringify({
+    version: 2,
+    items: [],
+    dont_consume: false,
+    images_per_execution: imagesPerExecution,
+    output_mode: outputMode,
+    reference_slots: referenceSlots,
+    ...state,
+  });
+  return {
+    id,
+    type,
+    inputs: [],
+    outputs: OUTPUT_NAMES.map((name) => ({ name, type: name === "mask" ? "MASK" : name.startsWith("ref_image_") || name === "image" || name === "last_frame" ? "IMAGE" : "*", links: [] })),
+    widgets: [{ name: "state_json", value: stateJson }],
+    properties: { ...properties },
+  };
+}
+
+function transformNode(id = 20) {
+  return {
+    id,
+    type: "ImageScaleToTotalPixelsX",
+    inputs: [{ name: "image", type: "IMAGE", link: null }],
+    outputs: [{ name: "IMAGE", type: "IMAGE", links: [] }],
+    widgets: [],
+  };
+}
+
+function bypassNode(id = 30) {
+  return {
+    id,
+    type: "Reroute",
+    mode: 4,
+    inputs: [{ name: "input", type: "IMAGE", link: null }],
+    outputs: [{ name: "output", type: "IMAGE", links: [] }],
+    widgets: [],
+  };
+}
+
+function graphWith(nodes) {
+  let nextLink = 1;
+  const links = {};
+  const graph = {
+    _nodes: nodes,
+    links,
+    getNodeById(id) { return this._nodes.find((node) => node.id === id) || null; },
+  };
+  nodes.forEach((node) => { node.graph = graph; });
+  return {
+    graph,
+    connect(source, sourceSlot, target, inputName) {
+      const targetSlot = target.inputs.findIndex((input) => input.name === inputName);
+      assert.notEqual(targetSlot, -1, `missing input ${inputName}`);
+      const linkId = nextLink++;
+      links[linkId] = {
+        origin_id: source.id,
+        origin_slot: sourceSlot,
+        target_id: target.id,
+        target_slot: targetSlot,
+      };
+      source.outputs[sourceSlot].links.push(linkId);
+      target.inputs[targetSlot].link = linkId;
+      return linkId;
+    },
+    app: { graph, canvas: { selected_nodes: {} } },
+  };
+}
+
+const ref = (name) => ({
+  annotated: `${name}.png [input]`,
+  filename: `${name}.png`,
+  subfolder: "",
+  type: "input",
+});
+
+test("persistent Image Conveyor excludes disabled and empty shelf outputs and disabled Main through a transform", () => {
+  const sampler = samplerNode();
+  const conveyor = conveyorNode({
+    referenceSlots: [ref("one"), null, ref("three"), ...Array(5).fill(null)],
+    state: {
+      reference_output_enabled: Array(8).fill(true),
+      main_output_enabled: true,
+      last_frame_output_enabled: true,
+    },
+    properties: {
+      image_conveyor_reference_enabled: [true, true, false, true, true, true, true, true],
+      image_conveyor_main_enabled: false,
+    },
+  });
+  const transform = transformNode();
+  const { app, connect } = graphWith([sampler, conveyor, transform]);
+
+  connect(conveyor, 0, transform, "image");
+  connect(transform, 0, sampler, "first_frame");
+  connect(conveyor, 6, sampler, "reference_image_1");
+  connect(conveyor, 7, sampler, "reference_image_2");
+  connect(conveyor, 8, sampler, "reference_image_3");
+  connect(conveyor, 14, sampler, "last_frame");
+
+  const inventory = discoverContinuumReferenceInventory(app, sampler);
+  assert.deepEqual(
+    inventory.items.map((item) => [item.role, item.tag ?? null, item.input_name]),
+    [
+      ["reference_image", "<Picture 1>", "reference_image_1"],
+      ["last_frame", null, "last_frame"],
+    ],
+  );
+  assert.deepEqual(validateContinuumModeTopology("Reference", inventory).actual, {
+    first_frame: false,
+    last_frame: true,
+    reference_images: 1,
+  });
+});
+
+test("persistent Image Conveyor properties override stale serialized toggle snapshots", () => {
+  const sampler = samplerNode();
+  const conveyor = conveyorNode({
+    referenceSlots: [ref("one"), ...Array(7).fill(null)],
+    state: {
+      reference_output_enabled: Array(8).fill(true),
+      main_output_enabled: true,
+      last_frame_output_enabled: true,
+    },
+    properties: {
+      image_conveyor_reference_enabled: [false, true, true, true, true, true, true, true],
+      image_conveyor_last_frame_enabled: false,
+    },
+  });
+  const { app, connect } = graphWith([sampler, conveyor]);
+  connect(conveyor, 6, sampler, "reference_image_1");
+  connect(conveyor, 14, sampler, "last_frame");
+
+  assert.deepEqual(discoverContinuumReferenceInventory(app, sampler).items, []);
+});
+
+test("queue-group Image Conveyor exposes only configured group members and ignores persistent toggles", () => {
+  const sampler = samplerNode();
+  const conveyor = conveyorNode({
+    type: "SequentialBatchImageLoader",
+    outputMode: "queue_group",
+    imagesPerExecution: 3,
+    state: {
+      dont_consume: true,
+      reference_output_enabled: Array(8).fill(false),
+      main_output_enabled: false,
+      last_frame_output_enabled: false,
+    },
+    properties: {
+      image_conveyor_reference_enabled: Array(8).fill(false),
+      image_conveyor_main_enabled: false,
+      image_conveyor_last_frame_enabled: false,
+    },
+  });
+  const { app, connect } = graphWith([sampler, conveyor]);
+
+  connect(conveyor, 0, sampler, "first_frame");
+  connect(conveyor, 6, sampler, "reference_image_1");
+  connect(conveyor, 7, sampler, "reference_image_3");
+  connect(conveyor, 8, sampler, "reference_image_4");
+  connect(conveyor, 14, sampler, "last_frame");
+
+  const inventory = discoverContinuumReferenceInventory(app, sampler);
+  assert.deepEqual(
+    inventory.items.map((item) => [item.role, item.tag ?? null, item.input_name]),
+    [
+      ["reference_image", "<Picture 1>", "reference_image_1"],
+      ["reference_image", "<Picture 2>", "reference_image_3"],
+      ["first_frame", null, "first_frame"],
+      ["last_frame", null, "last_frame"],
+    ],
+  );
+  assert.equal(inventory.items.some((item) => item.input_name === "reference_image_4"), false);
+});
+
+test("bypassed nodes resolve back to Image Conveyor effective reference state", () => {
+  const sampler = samplerNode();
+  const conveyor = conveyorNode({
+    referenceSlots: [null, ...Array(7).fill(null)],
+  });
+  const bypass = bypassNode();
+  const { app, connect } = graphWith([sampler, conveyor, bypass]);
+
+  connect(conveyor, 6, bypass, "input");
+  connect(bypass, 0, sampler, "reference_image_1");
+
+  assert.deepEqual(discoverContinuumReferenceInventory(app, sampler).items, []);
+});
+
+test("persistent Reference Shelf replacements change saved source identity without exposing filenames", () => {
+  const sampler = samplerNode();
+  const conveyor = conveyorNode({
+    referenceSlots: [ref("alpha"), ...Array(7).fill(null)],
+  });
+  const { app, connect } = graphWith([sampler, conveyor]);
+  connect(conveyor, 6, sampler, "reference_image_1");
+
+  const first = discoverContinuumReferenceInventory(app, sampler);
+  const firstIdentity = first.items[0].source_identity;
+  assert.match(firstIdentity, /^image-conveyor-ref-v1:[0-9a-f]{16}$/);
+  assert.equal(firstIdentity.includes("alpha"), false);
+
+  const stateWidget = conveyor.widgets.find((entry) => entry.name === "state_json");
+  const state = JSON.parse(stateWidget.value);
+  state.reference_slots[0] = ref("beta");
+  stateWidget.value = JSON.stringify(state);
+
+  const second = discoverContinuumReferenceInventory(app, sampler);
+  assert.match(second.items[0].source_identity, /^image-conveyor-ref-v1:[0-9a-f]{16}$/);
+  assert.notEqual(second.items[0].source_identity, firstIdentity);
+  assert.equal(sameContinuumReferenceInventory(first, second), false);
+});
+
+test("queue-group outputs remain intentionally dynamic and do not fingerprint queue members", () => {
+  const sampler = samplerNode();
+  const conveyor = conveyorNode({
+    outputMode: "queue_group",
+    imagesPerExecution: 3,
+  });
+  const { app, connect } = graphWith([sampler, conveyor]);
+  connect(conveyor, 0, sampler, "first_frame");
+  connect(conveyor, 6, sampler, "reference_image_1");
+  connect(conveyor, 7, sampler, "reference_image_2");
+
+  const inventory = discoverContinuumReferenceInventory(app, sampler);
+  assert.equal(inventory.items.length, 3);
+  assert.ok(inventory.items.every((item) => !Object.hasOwn(item, "source_identity")));
+});
+
+test("non-Conveyor image sources retain ordinary wire-based discovery", () => {
+  const sampler = samplerNode();
+  const loader = {
+    id: 50,
+    type: "LoadImage",
+    inputs: [],
+    outputs: [{ name: "IMAGE", type: "IMAGE", links: [] }],
+    widgets: [],
+  };
+  const { app, connect } = graphWith([sampler, loader]);
+  connect(loader, 0, sampler, "reference_image_4");
+
+  const inventory = discoverContinuumReferenceInventory(app, sampler);
+  assert.equal(inventory.items.length, 1);
+  assert.equal(inventory.items[0].tag, "<Picture 1>");
+  assert.equal(inventory.items[0].source_node_class, "LoadImage");
+});
+
+test("persistent active Conveyor Reference Shelf slots expose importable Writer media descriptors", () => {
+  const sampler = samplerNode();
+  const conveyor = conveyorNode({
+    referenceSlots: [ref("one"), ...Array(7).fill(null)],
+  });
+  const { app, connect } = graphWith([sampler, conveyor]);
+  connect(conveyor, 6, sampler, "reference_image_3");
+
+  const discovered = discoverContinuumWorkflowImageMedia(app, sampler);
+  assert.equal(discovered.candidates.length, 1);
+  assert.deepEqual(
+    {
+      label: discovered.candidates[0].label,
+      input_name: discovered.candidates[0].input_name,
+      importable: discovered.candidates[0].importable,
+      source_kind: discovered.candidates[0].source_kind,
+      file: discovered.candidates[0].file,
+    },
+    {
+      label: "<Picture 1>",
+      input_name: "reference_image_3",
+      importable: true,
+      source_kind: "image_conveyor_persistent",
+      file: { filename: "one.png", subfolder: "", type: "input" },
+    },
+  );
+});
+
+test("queue-group workflow image slots are visible in the UI contract but cannot be falsely materialized as stable files", () => {
+  const sampler = samplerNode();
+  const conveyor = conveyorNode({ outputMode: "queue_group", imagesPerExecution: 2 });
+  const { app, connect } = graphWith([sampler, conveyor]);
+  connect(conveyor, 6, sampler, "reference_image_1");
+
+  const candidate = discoverContinuumWorkflowImageMedia(app, sampler).candidates[0];
+  assert.equal(candidate.label, "<Picture 1>");
+  assert.equal(candidate.importable, false);
+  assert.equal(candidate.reason, "dynamic_queue_group");
+});
+
+test("processed Conveyor reference chains remain active conditioning but refuse an inexact pre-execution media copy", () => {
+  const sampler = samplerNode();
+  const conveyor = conveyorNode({
+    referenceSlots: [ref("one"), ...Array(7).fill(null)],
+  });
+  const transform = transformNode();
+  transform.type = "UnsupportedImageTransform";
+  const { app, connect } = graphWith([sampler, conveyor, transform]);
+  connect(conveyor, 6, transform, "image");
+  connect(transform, 0, sampler, "reference_image_1");
+
+  const candidate = discoverContinuumWorkflowImageMedia(app, sampler).candidates[0];
+  assert.equal(candidate.importable, false);
+  assert.equal(candidate.reason, "processed_image_chain");
+});
+
+test("direct LoadImage workflow references can be imported from their selected ComfyUI input file", () => {
+  const sampler = samplerNode();
+  const loader = {
+    id: 51,
+    type: "LoadImage",
+    inputs: [],
+    outputs: [{ name: "IMAGE", type: "IMAGE", links: [] }],
+    widgets: [{ name: "image", value: "characters/alice.png" }],
+  };
+  const { app, connect } = graphWith([sampler, loader]);
+  connect(loader, 0, sampler, "reference_image_1");
+
+  const discovered = discoverContinuumWorkflowImageMedia(app, sampler);
+  assert.equal(discovered.candidates[0].importable, true);
+  assert.deepEqual(discovered.candidates[0].file, {
+    filename: "alice.png",
+    subfolder: "characters",
+    type: "input",
+  });
+  assert.match(discovered.inventory.items[0].source_identity, /^load-image-v1:[0-9a-f]{16}$/);
+});
+
+test("bound workflow media makes exactly the matching active source visible to the prompt model", () => {
+  const sampler = samplerNode();
+  const conveyor = conveyorNode({
+    referenceSlots: [ref("one"), ...Array(7).fill(null)],
+  });
+  const { app, connect } = graphWith([sampler, conveyor]);
+  connect(conveyor, 6, sampler, "reference_image_1");
+
+  const discovered = discoverContinuumWorkflowImageMedia(app, sampler);
+  const candidate = discovered.candidates[0];
+  const bindings = {
+    [candidate.key]: {
+      asset_id: "asset-1",
+      source_identity: candidate.source_identity,
+    },
+  };
+  const bound = bindContinuumReferenceMedia(discovered.inventory, bindings, [{ id: "asset-1" }]);
+  assert.equal(bound.items[0].visible_to_model, true);
+  assert.equal(bound.items[0].model_asset_id, "asset-1");
+
+  bindings[candidate.key].source_identity = "image-conveyor-ref-v1:ffffffffffffffff";
+  const stale = bindContinuumReferenceMedia(discovered.inventory, bindings, [{ id: "asset-1" }]);
+  assert.equal(stale.items[0].visible_to_model, false);
+  assert.equal(Object.hasOwn(stale.items[0], "model_asset_id"), false);
+});
+
+test("Apply-to-Continuum source comparison ignores Prompt Writer media binding while preserving workflow source drift", () => {
+  const sampler = samplerNode();
+  const conveyor = conveyorNode({
+    referenceSlots: [ref("one"), ...Array(7).fill(null)],
+  });
+  const { app, connect } = graphWith([sampler, conveyor]);
+  connect(conveyor, 6, sampler, "reference_image_1");
+
+  const active = discoverContinuumReferenceInventory(app, sampler);
+  const saved = structuredClone(active);
+  saved.items[0].visible_to_model = true;
+  saved.items[0].model_asset_id = "asset-1";
+
+  assert.equal(sameContinuumReferenceInventory(saved, active), false);
+  assert.equal(sameContinuumWorkflowSourceInventory(saved, active), true);
+
+  const changed = structuredClone(active);
+  changed.items[0].source_identity = "image-conveyor-ref-v1:ffffffffffffffff";
+  assert.equal(sameContinuumWorkflowSourceInventory(saved, changed), false);
+});
+
+test("reviewed Scale Image to Total Pixels Adv chain is materializable and transform-aware", () => {
+  const sampler = samplerNode();
+  const conveyor = conveyorNode({
+    referenceSlots: [ref("one"), ...Array(7).fill(null)],
+  });
+  const scale = {
+    id: 60,
+    type: "ImageScaleToTotalPixelsX",
+    inputs: [
+      { name: "image", type: "IMAGE", link: null },
+      { name: "width", type: "INT", link: null },
+      { name: "height", type: "INT", link: null },
+    ],
+    outputs: [
+      { name: "image", type: "IMAGE", links: [] },
+      { name: "width", type: "INT", links: [] },
+      { name: "height", type: "INT", links: [] },
+    ],
+    widgets: [
+      { name: "megapixels", value: 0.70 },
+      { name: "multiple_of", value: 32 },
+      { name: "resize_mode", value: "crop" },
+      { name: "upscale_method", value: "lanczos" },
+    ],
+  };
+  const { app, connect } = graphWith([sampler, conveyor, scale]);
+  connect(conveyor, 6, scale, "image");
+  connect(scale, 0, sampler, "reference_image_1");
+
+  const discovered = discoverContinuumWorkflowImageMedia(app, sampler);
+  const candidate = discovered.candidates[0];
+  assert.equal(candidate.importable, true);
+  assert.equal(candidate.source_kind, "scale_image_to_total_pixels_x");
+  assert.equal(candidate.materialization_plan.contract_sha, "79e831097bb7a76ade3a28359300e62332086c42");
+  assert.deepEqual(candidate.materialization_plan, {
+    kind: "image_scale_to_total_pixels_x",
+    version: 1,
+    node_class: "ImageScaleToTotalPixelsX",
+    contract_sha: "79e831097bb7a76ade3a28359300e62332086c42",
+    megapixels: 0.70,
+    multiple_of: 32,
+    resize_mode: "crop",
+    upscale_method: "lanczos",
+  });
+  assert.match(candidate.source_identity, /^workflow-materialized-v1:[0-9a-f]{16}$/);
+  assert.equal(discovered.inventory.items[0].source_identity, candidate.source_identity);
+
+  const before = candidate.source_identity;
+  scale.widgets.find((entry) => entry.name === "megapixels").value = 0.80;
+  const after = discoverContinuumWorkflowImageMedia(app, sampler).candidates[0].source_identity;
+  assert.notEqual(after, before);
+});
+
+test("Scale Image to Total Pixels Adv fails closed for dynamic overrides and unreviewed resize methods", () => {
+  const sampler = samplerNode();
+  const conveyor = conveyorNode({
+    referenceSlots: [ref("one"), ...Array(7).fill(null)],
+  });
+  const scale = {
+    id: 61,
+    type: "ImageScaleToTotalPixelsX",
+    inputs: [
+      { name: "image", type: "IMAGE", link: null },
+      { name: "width", type: "INT", link: 999 },
+      { name: "height", type: "INT", link: null },
+    ],
+    outputs: [{ name: "image", type: "IMAGE", links: [] }],
+    widgets: [
+      { name: "megapixels", value: 0.70 },
+      { name: "multiple_of", value: 32 },
+      { name: "resize_mode", value: "crop" },
+      { name: "upscale_method", value: "lanczos" },
+    ],
+  };
+  const { app, connect } = graphWith([sampler, conveyor, scale]);
+  connect(conveyor, 6, scale, "image");
+  connect(scale, 0, sampler, "reference_image_1");
+
+  let candidate = discoverContinuumWorkflowImageMedia(app, sampler).candidates[0];
+  assert.equal(candidate.importable, false);
+  assert.equal(candidate.reason, "dynamic_transform_parameters");
+
+  scale.inputs.find((entry) => entry.name === "width").link = null;
+  scale.inputs.push({ name: "megapixels", type: "FLOAT", link: 1001 });
+  candidate = discoverContinuumWorkflowImageMedia(app, sampler).candidates[0];
+  assert.equal(candidate.importable, false);
+  assert.equal(candidate.reason, "dynamic_transform_parameters");
+
+  scale.inputs.find((entry) => entry.name === "megapixels").link = null;
+  scale.widgets.find((entry) => entry.name === "upscale_method").value = "bicubic";
+  candidate = discoverContinuumWorkflowImageMedia(app, sampler).candidates[0];
+  assert.equal(candidate.importable, false);
+  assert.equal(candidate.reason, "unsupported_transform_method");
+});
+
+test("unreadable Image Conveyor state fails closed instead of inventing public identities", () => {
+  const sampler = samplerNode();
+  const conveyor = conveyorNode();
+  conveyor.widgets[0].value = "{broken";
+  delete conveyor.__bil;
+  const { app, connect } = graphWith([sampler, conveyor]);
+  connect(conveyor, 6, sampler, "reference_image_1");
+
+  assert.throws(
+    () => discoverContinuumReferenceInventory(app, sampler),
+    /no readable state_json/,
+  );
+});

--- a/tests/test_continuum_routes.py
+++ b/tests/test_continuum_routes.py
@@ -1,0 +1,531 @@
+from __future__ import annotations
+
+import json
+import sys
+import types
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class _FakeRoutes:
+    def get(self, _path):
+        return lambda function: function
+
+    post = get
+    delete = get
+
+
+sys.modules.setdefault(
+    "server",
+    types.SimpleNamespace(
+        PromptServer=types.SimpleNamespace(instance=types.SimpleNamespace(routes=_FakeRoutes()))
+    ),
+)
+
+from backend import routes  # noqa: E402
+
+
+class _Request:
+    def __init__(self, body):
+        self._body = body
+
+    async def json(self):
+        return self._body
+
+
+def _settings(chunks=2, chunk_seconds=5):
+    return {
+        "schema_version": 2,
+        "chunks": chunks,
+        "chunk_seconds": float(chunk_seconds),
+        "total_seconds": chunks * float(chunk_seconds),
+    }
+
+
+def _plan(chunks=2, *, preamble="Stable identity, wardrobe, location, camera language, lighting, and room tone persist."):
+    return {
+        "schema_version": 2,
+        "global": {
+            "sequence_preamble": preamble,
+            "continuity_anchors": "Same subject, place, wardrobe, camera axis, light, and room tone.",
+            "persistent_constraints": "Preserve the requested continuity and exclusions.",
+            "subject_anchors": [],
+        },
+        "chunks": [
+            {
+                "continuity": "initial" if index == 1 else "continuous",
+                "transition": "",
+                "start_state": f"Start {index}.",
+                "action": f"Action {index}.",
+                "end_state": f"End {index}.",
+            }
+            for index in range(1, chunks + 1)
+        ],
+    }
+
+
+class ContinuumRouteTests(unittest.IsolatedAsyncioTestCase):
+    session_id = "11111111-2222-4333-8444-555555555555"
+
+    def setUp(self):
+        routes.STATE.update({
+            "phase": "idle",
+            "active_request_id": None,
+            "selected_model_id": None,
+            "selected_model_family": None,
+            "cancel_requested": False,
+            "pending_unload_family": None,
+            "pending_unload_model_id": None,
+            "pending_unload_endpoint": None,
+            "sequence_chunk_index": None,
+            "sequence_chunk_total": None,
+        })
+
+    def tearDown(self):
+        routes._release_generation_request(routes.STATE.get("active_request_id") or "")
+
+    def body(self, chunks=2, chunk_seconds=5):
+        return {
+            "session_id": self.session_id,
+            "mode": "T2VA",
+            "generation_target": "continuum",
+            "continuum": {"schema_version": 2, "chunks": chunks, "chunk_seconds": chunk_seconds},
+            "duration_seconds": chunk_seconds,
+            "aspect_ratio": "16:9",
+            "creative_brief": "A continuous walk through one room.",
+            "downstream_reference_inventory": {"schema_version": 1, "items": []},
+            "model_id": "test-model",
+            "seed": 10,
+            "unload_after": True,
+        }
+
+    @staticmethod
+    def payload(response):
+        return json.loads(response.body.decode("utf-8"))
+
+    async def run_sequence(self, stage_results, *, chunks=2, chunk_seconds=5, cancelled=False):
+        body = self.body(chunks, chunk_seconds)
+        assembled = {
+            "input": {
+                "media_manifest": {"assets": []},
+                "downstream_reference_inventory": {"schema_version": 1, "items": []},
+            }
+        }
+        model = {"id": "test-model", "name": "Test", "family": "test", "format": "test"}
+        backend = MagicMock(externally_managed=False)
+        stage = AsyncMock(side_effect=stage_results)
+        chunk_assembled = {
+            "input": {
+                "mode": "T2VA",
+                "generation_target": "continuum",
+                "media_manifest": {"assets": []},
+                "continuum_plan": _plan(chunks),
+            },
+        }
+        with (
+            patch.object(routes, "_prepare_generation_runtime", new_callable=AsyncMock, return_value=(model, backend, {"context_profile": "standard", "kv_cache": "q8"})),
+            patch.object(routes, "_run_generation_stage", stage),
+            patch.object(routes, "_preflight_sequence_stage", new_callable=AsyncMock, return_value={"context_profile": "standard", "kv_cache": "q8"}),
+            patch.object(routes, "assemble_continuum_chunk_request", return_value=chunk_assembled),
+            patch.object(routes, "_request_cancelled", return_value=cancelled),
+            patch.object(routes, "write_event"),
+            patch.object(routes.PeakVRAMMonitor, "start"),
+            patch.object(routes.PeakVRAMMonitor, "stop", return_value=0),
+        ):
+            response = await routes._generate_continuum(body, assembled, _settings(chunks, chunk_seconds))
+        return response, stage, backend
+
+    async def test_generate_returns_400_for_continuum_mode_topology_preflight(self):
+        error = routes.ContinuumError(
+            "CONTINUUM_MODE_TOPOLOGY_MISMATCH",
+            "The selected mode does not match the V3.4 conditioning topology.",
+            {"mode": "T2VA"},
+        )
+        with patch.object(routes, "assemble_continuum_plan_request", side_effect=error):
+            response = await routes.generate(_Request(self.body()))
+        self.assertEqual(response.status, 400)
+        self.assertEqual(
+            self.payload(response)["error"]["code"],
+            "CONTINUUM_MODE_TOPOLOGY_MISMATCH",
+        )
+
+    async def test_refine_returns_400_for_saved_continuum_source_drift_preflight(self):
+        body = self.body()
+        body.update({
+            "current_prompt": "[0-5s]\nOne.\n\n[5-10s]\nTwo.",
+            "instruction": "Slow Chunk 2.",
+        })
+        error = routes.ContinuumError(
+            "CONTINUUM_REFERENCE_SOURCE_DRIFT",
+            "The selected V3.4 conditioning sources changed.",
+            {"saved_inventory": {}, "active_inventory": {}},
+        )
+        with patch.object(routes, "assemble_continuum_refinement", side_effect=error):
+            response = await routes.refine(_Request(body))
+        self.assertEqual(response.status, 400)
+        self.assertEqual(
+            self.payload(response)["error"]["code"],
+            "CONTINUUM_REFERENCE_SOURCE_DRIFT",
+        )
+
+    async def test_sequence_calls_planner_then_chunks_and_returns_canonical_timeline(self):
+        response, stage, _backend = await self.run_sequence([
+            {"prompt": json.dumps(_plan()), "output_tokens": 10, "generation_seconds": 1},
+            {"prompt": "Complete H3 prompt one.", "output_tokens": 20, "generation_seconds": 2},
+            {"prompt": "Complete H3 prompt two.", "output_tokens": 30, "generation_seconds": 3},
+        ])
+        self.assertEqual(response.status, 200)
+        payload = self.payload(response)
+        self.assertEqual(payload["generation_target"], "continuum")
+        self.assertEqual(
+            payload["prompt"],
+            "Stable identity, wardrobe, location, camera language, lighting, and room tone persist.\n\n"
+            "[0-5s]\nComplete H3 prompt one.\n\n"
+            "[5-10s]\nComplete H3 prompt two.",
+        )
+        self.assertEqual(payload["sequence"]["preamble"], _plan()["global"]["sequence_preamble"])
+        self.assertEqual(payload["sequence"]["chunks"][0]["resolved_prompt"], (
+            _plan()["global"]["sequence_preamble"] + "\n\nComplete H3 prompt one."
+        ))
+        self.assertEqual(payload["sequence_request_count"], 3)
+        self.assertEqual(payload["output_tokens"], 60)
+        self.assertEqual([call.kwargs["unload_after"] for call in stage.await_args_list], [False, False, True])
+        self.assertEqual(
+            [call.kwargs["seed"] for call in stage.await_args_list],
+            [10, routes._sequence_seed(10, 1), routes._sequence_seed(10, 2)],
+        )
+        self.assertIsNone(routes.STATE["active_request_id"])
+
+    async def test_fractional_duration_serializes_exact_boundaries(self):
+        response, _stage, _backend = await self.run_sequence([
+            {"prompt": json.dumps(_plan(3))},
+            {"prompt": "One."},
+            {"prompt": "Two."},
+            {"prompt": "Three."},
+        ], chunks=3, chunk_seconds=6.5)
+        self.assertEqual(response.status, 200)
+        prompt = self.payload(response)["prompt"]
+        self.assertIn("[0-6.5s]\nOne.", prompt)
+        self.assertIn("[6.5-13s]\nTwo.", prompt)
+        self.assertIn("[13-19.5s]\nThree.", prompt)
+
+    async def test_empty_internal_planning_fields_do_not_trigger_repair(self):
+        planned = _plan()
+        planned["global"]["continuity_anchors"] = ""
+        planned["global"]["persistent_constraints"] = ""
+        response, stage, _backend = await self.run_sequence([
+            {"prompt": json.dumps(planned)},
+            {"prompt": "Prompt one."},
+            {"prompt": "Prompt two."},
+        ])
+        self.assertEqual(response.status, 200)
+        payload = self.payload(response)
+        self.assertFalse(payload["planner_repair_attempted"])
+        self.assertFalse(payload["planner_contract_recovery_applied"])
+        self.assertEqual(payload["sequence"]["plan"]["global"]["continuity_anchors"], "")
+        self.assertEqual(payload["sequence"]["plan"]["global"]["persistent_constraints"], "")
+        self.assertEqual(stage.await_count, 3)
+
+    async def test_malformed_plan_gets_exactly_one_narrow_repair(self):
+        response, stage, _backend = await self.run_sequence([
+            {"prompt": "not json"},
+            {"prompt": json.dumps(_plan())},
+            {"prompt": "Prompt one."},
+            {"prompt": "Prompt two."},
+        ])
+        self.assertEqual(response.status, 200)
+        self.assertTrue(self.payload(response)["planner_repair_attempted"])
+        self.assertEqual(stage.await_count, 4)
+        self.assertEqual(
+            [call.kwargs["unload_after"] for call in stage.await_args_list],
+            [False, False, False, True],
+        )
+
+    async def test_non_json_initial_then_empty_preamble_repair_recovers_without_third_model_call(self):
+        repaired = _plan()
+        repaired["global"]["sequence_preamble"] = ""
+        repaired["global"]["continuity_anchors"] = "Same subject, room, wardrobe, camera axis, light, and room tone."
+        repaired["global"]["persistent_constraints"] = "Preserve the requested continuity and exclusions."
+
+        response, stage, _backend = await self.run_sequence([
+            {"prompt": "not json at all"},
+            {"prompt": json.dumps(repaired)},
+            {"prompt": "Prompt one."},
+            {"prompt": "Prompt two."},
+        ])
+        self.assertEqual(response.status, 200)
+        payload = self.payload(response)
+        self.assertTrue(payload["planner_repair_attempted"])
+        self.assertTrue(payload["planner_contract_recovery_applied"])
+        self.assertIn("synthesized_sequence_preamble", payload["planner_contract_recovery_actions"])
+        self.assertEqual(stage.await_count, 4)
+        self.assertIn(
+            "Same subject, room, wardrobe, camera axis, light, and room tone.",
+            payload["sequence"]["preamble"],
+        )
+
+    async def test_wrapped_valid_initial_plan_is_recovered_without_spending_llm_repair(self):
+        wrapped = "Planner result follows:\n" + json.dumps(_plan()) + "\nEnd planner result."
+        response, stage, _backend = await self.run_sequence([
+            {"prompt": wrapped},
+            {"prompt": "Prompt one."},
+            {"prompt": "Prompt two."},
+        ])
+        self.assertEqual(response.status, 200)
+        payload = self.payload(response)
+        self.assertFalse(payload["planner_repair_attempted"])
+        self.assertTrue(payload["planner_contract_recovery_applied"])
+        self.assertEqual(payload["planner_contract_recovery_actions"], ["extracted_embedded_json"])
+        self.assertEqual(stage.await_count, 3)
+
+    async def test_llm_repair_survives_alphabetic_subject_aliases(self):
+        repaired = _plan()
+        repaired["global"]["subject_anchors"] = [
+            {"id": "<Subject A>", "meaning": "<Subject A> is the same courier throughout."}
+        ]
+        repaired["global"]["sequence_preamble"] += " Keep <Subject A> visually stable."
+        repaired["chunks"][0]["start_state"] = "<Subject A> begins by the door."
+        repaired["chunks"][1]["action"] = "<Subject A> crosses the room."
+
+        response, stage, _backend = await self.run_sequence([
+            {"prompt": "not json"},
+            {"prompt": json.dumps(repaired)},
+            {"prompt": "Prompt one."},
+            {"prompt": "Prompt two."},
+        ])
+        self.assertEqual(response.status, 200)
+        payload = self.payload(response)
+        self.assertTrue(payload["planner_repair_attempted"])
+        self.assertFalse(payload["planner_contract_recovery_applied"])
+        self.assertEqual(stage.await_count, 4)
+        normalized = payload["sequence"]["plan"]
+        self.assertEqual(
+            normalized["global"]["subject_anchors"],
+            [{"id": "<Subject 1>", "meaning": "<Subject 1> is the same courier throughout."}],
+        )
+        self.assertNotIn("<Subject A>", json.dumps(normalized))
+        self.assertIn("<Subject 1>", normalized["global"]["sequence_preamble"])
+        self.assertIn("<Subject 1>", normalized["chunks"][1]["action"])
+
+    async def test_chunk_failure_reports_its_index_and_unloads_the_acquired_runtime(self):
+        unload = AsyncMock()
+        body = self.body(3)
+        assembled = {"input": {"media_manifest": {"assets": []}}}
+        model = {"id": "test-model", "name": "Test", "family": "test", "format": "test"}
+        backend = MagicMock(externally_managed=False)
+        stage = AsyncMock(side_effect=[
+            {"prompt": json.dumps(_plan(3))},
+            {"prompt": "Prompt one."},
+            {"prompt": "[5-10s]\nNested reserved header."},
+        ])
+        chunk_assembled = {
+            "input": {
+                "mode": "T2VA",
+                "generation_target": "continuum",
+                "media_manifest": {"assets": []},
+                "continuum_plan": _plan(3),
+            },
+        }
+        with (
+            patch.object(routes, "_prepare_generation_runtime", new_callable=AsyncMock, return_value=(model, backend, {"context_profile": "standard", "kv_cache": "q8"})),
+            patch.object(routes, "_run_generation_stage", stage),
+            patch.object(routes, "_preflight_sequence_stage", new_callable=AsyncMock, return_value={}),
+            patch.object(routes, "assemble_continuum_chunk_request", return_value=chunk_assembled),
+            patch.object(routes, "_unload_failed_sequence", unload),
+            patch.object(routes, "write_event"),
+            patch.object(routes.PeakVRAMMonitor, "start"),
+            patch.object(routes.PeakVRAMMonitor, "stop", return_value=0),
+        ):
+            response = await routes._generate_continuum(body, assembled, _settings(3))
+        self.assertEqual(response.status, 502)
+        error = self.payload(response)["error"]
+        self.assertEqual(error["code"], "INVALID_CONTINUUM_CHUNK_FORMAT")
+        self.assertIn("Chunk 2", error["message"])
+        self.assertEqual(error["details"]["chunk_index"], 2)
+        unload.assert_awaited_once_with(backend, model, body)
+
+    async def test_pending_cancellation_stops_before_the_first_chunk(self):
+        unload = AsyncMock()
+        body = self.body()
+        assembled = {"input": {"media_manifest": {"assets": []}}}
+        model = {"id": "test-model", "name": "Test", "family": "test", "format": "test"}
+        backend = MagicMock(externally_managed=False)
+        stage = AsyncMock(return_value={"prompt": json.dumps(_plan())})
+        with (
+            patch.object(routes, "_prepare_generation_runtime", new_callable=AsyncMock, return_value=(model, backend, {"context_profile": "standard", "kv_cache": "q8"})),
+            patch.object(routes, "_run_generation_stage", stage),
+            patch.object(routes, "_request_cancelled", return_value=True),
+            patch.object(routes, "_unload_failed_sequence", unload),
+            patch.object(routes, "write_event"),
+            patch.object(routes.PeakVRAMMonitor, "start"),
+            patch.object(routes.PeakVRAMMonitor, "stop", return_value=0),
+        ):
+            response = await routes._generate_continuum(body, assembled, _settings())
+        self.assertEqual(response.status, 499)
+        self.assertEqual(self.payload(response)["error"]["code"], "GENERATION_CANCELLED")
+        self.assertEqual(stage.await_count, 1)
+        unload.assert_awaited_once_with(backend, model, body)
+
+    async def test_backend_failure_during_a_chunk_is_annotated_with_the_chunk_index(self):
+        failure = routes.ModelError("API_RATE_LIMITED", "Quota window exhausted.", {"retry_after": 30})
+        response, stage, _backend = await self.run_sequence([
+            {"prompt": json.dumps(_plan())},
+            {"prompt": "Prompt one."},
+            failure,
+        ])
+        self.assertEqual(response.status, 429)
+        error = self.payload(response)["error"]
+        self.assertEqual(error["code"], "API_RATE_LIMITED")
+        self.assertIn("Chunk 2", error["message"])
+        self.assertEqual(error["details"], {"chunk_index": 2, "cause": {"retry_after": 30}})
+        self.assertEqual(stage.await_count, 3)
+
+    async def test_invalid_native_bounds_stop_before_sequence_generation(self):
+        body = self.body()
+        body["continuum"]["chunks"] = 17
+        with patch.object(routes, "_generate_continuum", new_callable=AsyncMock) as sequence:
+            response = await routes.generate(_Request(body))
+        self.assertEqual(response.status, 400)
+        self.assertEqual(self.payload(response)["error"]["code"], "INVALID_CONTINUUM_CHUNKS")
+        sequence.assert_not_awaited()
+
+    async def test_continuum_refine_route_preserves_preamble_and_untouched_chunks(self):
+        preamble = _plan()["global"]["sequence_preamble"]
+        body = self.body()
+        body["current_prompt"] = (
+            preamble + "\n\n[0-5s]\nPrompt one.\n\n[5-10s]\nPrompt two."
+        )
+        body["instruction"] = "Tighten the second chunk without changing the first."
+        body["continuum"]["plan"] = _plan()
+        body["continuum"]["chunk_index"] = 2
+        assembled = {
+            "input": {
+                "mode": "T2VA",
+                "generation_target": "continuum",
+                "continuum": _settings(),
+                "continuum_plan": _plan(),
+                "media_manifest": {"assets": []},
+            }
+        }
+        sequence_state = {"preamble": preamble, "prompts": ["Prompt one.", "Prompt two."]}
+        model = {"id": "test-model", "name": "Test", "family": "test", "format": "test"}
+        backend = MagicMock(externally_managed=False)
+        with (
+            patch.object(
+                routes,
+                "assemble_continuum_refinement",
+                return_value=(assembled, sequence_state, 2, _plan()),
+            ),
+            patch.object(
+                routes,
+                "_prepare_generation_runtime",
+                new_callable=AsyncMock,
+                return_value=(model, backend, {"context_profile": "standard", "kv_cache": "q8"}),
+            ),
+            patch.object(
+                routes,
+                "_run_thread_worker",
+                new_callable=AsyncMock,
+                return_value=({"prompt": "Refined prompt two."}, None),
+            ),
+            patch.object(routes, "write_event"),
+            patch.object(routes.PeakVRAMMonitor, "start"),
+            patch.object(routes.PeakVRAMMonitor, "stop", return_value=0),
+        ):
+            response = await routes.refine(_Request(body))
+
+        self.assertEqual(response.status, 200)
+        payload = self.payload(response)
+        self.assertEqual(payload["generation_target"], "continuum")
+        self.assertEqual(payload["chunk_index"], 2)
+        self.assertEqual(payload["chunk_prompt"], "Refined prompt two.")
+        self.assertEqual(
+            payload["prompt"],
+            preamble + "\n\n[0-5s]\nPrompt one.\n\n[5-10s]\nRefined prompt two.",
+        )
+        self.assertEqual(
+            [item["body"] for item in payload["sequence"]["chunks"]],
+            ["Prompt one.", "Refined prompt two."],
+        )
+
+    async def test_continuum_refine_route_annotates_backend_failure_with_chunk(self):
+        body = self.body()
+        body["current_prompt"] = "Global.\n\n[0-5s]\nPrompt one.\n\n[5-10s]\nPrompt two."
+        body["instruction"] = "Tighten the second chunk."
+        body["continuum"]["plan"] = _plan(preamble="Global.")
+        body["continuum"]["chunk_index"] = 2
+        assembled = {
+            "input": {
+                "mode": "T2VA",
+                "generation_target": "continuum",
+                "continuum": _settings(),
+                "continuum_plan": _plan(preamble="Global."),
+                "media_manifest": {"assets": []},
+            }
+        }
+        model = {"id": "test-model", "name": "Test", "family": "test", "format": "test"}
+        backend = MagicMock(externally_managed=False)
+        failure = routes.ModelError("API_RATE_LIMITED", "Quota window exhausted.", {"retry_after": 30})
+        with (
+            patch.object(
+                routes,
+                "assemble_continuum_refinement",
+                return_value=(assembled, {"preamble": "Global.", "prompts": ["Prompt one.", "Prompt two."]}, 2, _plan(preamble="Global.")),
+            ),
+            patch.object(
+                routes,
+                "_prepare_generation_runtime",
+                new_callable=AsyncMock,
+                return_value=(model, backend, {"context_profile": "standard", "kv_cache": "q8"}),
+            ),
+            patch.object(routes, "_run_thread_worker", new_callable=AsyncMock, side_effect=failure),
+            patch.object(routes, "write_event"),
+            patch.object(routes.PeakVRAMMonitor, "start"),
+            patch.object(routes.PeakVRAMMonitor, "stop", return_value=0),
+        ):
+            response = await routes.refine(_Request(body))
+
+        self.assertEqual(response.status, 429)
+        error = self.payload(response)["error"]
+        self.assertEqual(error["code"], "API_RATE_LIMITED")
+        self.assertIn("Continuum refinement failed at Chunk 2", error["message"])
+        self.assertEqual(error["details"], {"chunk_index": 2, "cause": {"retry_after": 30}})
+
+
+class ContinuumMetricsTests(unittest.TestCase):
+    def test_model_output_continuum_errors_map_to_bad_gateway(self):
+        for code in (
+            "EMPTY_CONTINUUM_CHUNK",
+            "INVALID_CONTINUUM_SEQUENCE",
+            "CONTINUUM_REFERENCE_IDENTITY_DRIFT",
+            "CONTINUUM_REFERENCE_SCOPE_DRIFT",
+            "CONTINUUM_SUBJECT_IDENTITY_DRIFT",
+        ):
+            with self.subTest(code=code):
+                self.assertEqual(routes._model_error_status(routes.ModelError(code, "bad model output")), 502)
+
+    def test_saved_conditioning_source_drift_is_a_request_error_not_bad_gateway(self):
+        self.assertEqual(
+            routes._model_error_status(
+                routes.ModelError(
+                    "CONTINUUM_REFERENCE_SOURCE_DRIFT",
+                    "saved workflow conditioning changed",
+                )
+            ),
+            400,
+        )
+
+    def test_final_provider_counters_are_kept_while_stage_tokens_are_summed(self):
+        metrics = routes._aggregate_sequence_metrics([
+            {"output_tokens": 10, "generation_seconds": 1, "provider_request_count": 1},
+            {"output_tokens": 20, "generation_seconds": 2, "provider_request_count": 2},
+            {"output_tokens": 30, "generation_seconds": 3, "provider_request_count": 3, "provider_request_ids": ["one", "two", "three"]},
+        ])
+        self.assertEqual(metrics["sequence_request_count"], 3)
+        self.assertEqual(metrics["output_tokens"], 60)
+        self.assertEqual(metrics["provider_request_count"], 3)
+        self.assertEqual(metrics["provider_request_ids"], ["one", "two", "three"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_direct_music.py
+++ b/tests/test_direct_music.py
@@ -358,7 +358,10 @@ class DirectMusicRuntimeTests(unittest.TestCase):
             )
 
         self.assertEqual(raised.exception.code, "DIRECT_VISION_REQUIRED")
-        self.assertEqual(raised.exception.details["supported_modes"], ["T2VA"])
+        self.assertEqual(
+            raised.exception.details["supported_without_vision"],
+            ["T2VA", "H3 Continuum modes using only workflow-declared conditioning"],
+        )
         self.assertIsNone(backend.model)
 
     def test_direct_model_without_template_control_rejects_thinking_before_load(self):

--- a/tests/test_image_conveyor_cross_repo.py
+++ b/tests/test_image_conveyor_cross_repo.py
@@ -1,0 +1,177 @@
+import importlib.util
+import json
+import os
+from pathlib import Path
+import sys
+import types
+import unittest
+
+
+class _FakeLoadImage:
+    calls = []
+
+    def load_image(self, annotated):
+        self.calls.append(annotated)
+        return f"image:{annotated}", f"mask:{annotated}"
+
+
+def _load_conveyor(source_root: Path):
+    folder_paths = types.ModuleType("folder_paths")
+    folder_paths.exists_annotated_filepath = lambda _value: True
+    folder_paths.get_annotated_filepath = lambda value: value
+    nodes = types.ModuleType("nodes")
+    nodes.LoadImage = _FakeLoadImage
+    previous = {name: sys.modules.get(name) for name in ("folder_paths", "nodes")}
+    sys.modules["folder_paths"] = folder_paths
+    sys.modules["nodes"] = nodes
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "reviewed_image_conveyor",
+            source_root / "image_conveyor.py",
+        )
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, value in previous.items():
+            if value is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = value
+
+
+def _item(name):
+    return {
+        "id": name,
+        "annotated": f"{name}.png [input]",
+        "filename": f"{name}.png",
+        "subfolder": "",
+        "source_path": "",
+        "type": "input",
+        "status": "pending",
+        "added_at": 0,
+        "last_queued_at": 0,
+        "last_processed_at": 0,
+    }
+
+
+def _reference(name):
+    return {
+        "annotated": f"{name}.png [input]",
+        "filename": f"{name}.png",
+        "subfolder": "",
+        "type": "input",
+    }
+
+
+class ImageConveyorCrossRepositoryContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        raw = os.environ.get("IMAGE_CONVEYOR_SOURCE", "").strip()
+        if not raw:
+            raise unittest.SkipTest("IMAGE_CONVEYOR_SOURCE is not set")
+        cls.root = Path(raw)
+        cls.conveyor = _load_conveyor(cls.root)
+
+    def setUp(self):
+        _FakeLoadImage.calls.clear()
+
+    def test_output_slots_and_aliases_match_prompt_writer_adapter(self):
+        self.assertEqual(
+            (
+                "image",
+                "mask",
+                "path",
+                "index",
+                "remaining_pending",
+                "source_path",
+                "ref_image_1",
+                "ref_image_2",
+                "ref_image_3",
+                "ref_image_4",
+                "ref_image_5",
+                "ref_image_6",
+                "ref_image_7",
+                "ref_image_8",
+                "last_frame",
+            ),
+            self.conveyor.ImageConveyor.RETURN_NAMES,
+        )
+        self.assertIs(
+            self.conveyor.NODE_CLASS_MAPPINGS["ImageConveyor"],
+            self.conveyor.NODE_CLASS_MAPPINGS["SequentialBatchImageLoader"],
+        )
+        self.assertEqual(8, self.conveyor._REFERENCE_SLOT_COUNT)
+        self.assertEqual(9, self.conveyor._MAX_IMAGES_PER_EXECUTION)
+        self.assertEqual("persistent_refs", self.conveyor._OUTPUT_MODE_PERSISTENT)
+        self.assertEqual("queue_group", self.conveyor._OUTPUT_MODE_QUEUE_GROUP)
+
+    def test_persistent_reference_outputs_are_fixed_shelf_slots_and_empty_slots_are_none(self):
+        state = self.conveyor._default_state()
+        state["output_mode"] = "persistent_refs"
+        state["reference_slots"] = [_reference("one"), None, _reference("three"), *([None] * 5)]
+        queued = json.dumps({
+            "reference_output_slots": [1, 2],
+            "queue_output_slots": [],
+            "main_output_enabled": False,
+        })
+        result = self.conveyor.ImageConveyor().load_next(
+            json.dumps(state),
+            queue_item_json=queued,
+        )["result"]
+        self.assertEqual("image:one.png [input]", result[6])
+        self.assertIsNone(result[7])
+        self.assertIsNone(result[8])
+        self.assertIsNone(result[0])
+        self.assertIsNone(result[14])
+
+    def test_queue_group_mapping_matches_images_per_execution_and_last_frame_alias(self):
+        state = self.conveyor._default_state()
+        state["output_mode"] = "queue_group"
+        state["images_per_execution"] = 3
+        state["dont_consume"] = True
+        state["items"] = [_item("A"), _item("B"), _item("C")]
+        queued = json.dumps({
+            "id": "A",
+            "annotated": "A.png [input]",
+            "items": [
+                {"id": "A", "annotated": "A.png [input]"},
+                {"id": "B", "annotated": "B.png [input]"},
+                {"id": "C", "annotated": "C.png [input]"},
+            ],
+        })
+        result = self.conveyor.ImageConveyor().load_next(
+            json.dumps(state),
+            queue_item_json=queued,
+        )["result"]
+        self.assertEqual("image:A.png [input]", result[0])
+        self.assertEqual("image:B.png [input]", result[6])
+        self.assertEqual("image:C.png [input]", result[7])
+        self.assertIsNone(result[8])
+        self.assertEqual(result[6], result[14])
+
+    def test_frontend_toggle_property_and_snapshot_names_are_pinned(self):
+        reference_source = (self.root / "web" / "image_conveyor_reference_toggles.js").read_text("utf-8")
+        last_frame_source = (self.root / "web" / "image_conveyor_last_frame_toggle.js").read_text("utf-8")
+        sync_source = (self.root / "web" / "image_conveyor_toggle_state_sync.js").read_text("utf-8")
+        math_source = (self.root / "web" / "image_conveyor_toggle_state_math.mjs").read_text("utf-8")
+        for token in (
+            "image_conveyor_reference_enabled",
+            "image_conveyor_main_enabled",
+            "reference_output_enabled",
+            "main_output_enabled",
+        ):
+            self.assertIn(token, reference_source)
+        self.assertIn("image_conveyor_last_frame_enabled", last_frame_source)
+        self.assertIn("image_conveyor_last_frame_enabled", sync_source)
+        for token in (
+            "last_frame_output_enabled",
+            "queue_output_slots",
+            "reference_output_slots",
+        ):
+            self.assertIn(token, math_source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_media_policy.py
+++ b/tests/test_media_policy.py
@@ -1,6 +1,15 @@
+import tempfile
 import unittest
+from pathlib import Path
 
-from backend.media import MediaError, validate_reference_durations
+from PIL import Image, ImageChops
+
+from backend.media import (
+    MediaError,
+    materialize_workflow_image,
+    normalize_workflow_materialization_plan,
+    validate_reference_durations,
+)
 
 
 def clip(kind: str, duration: float) -> dict:
@@ -19,6 +28,53 @@ class ReferenceDurationTests(unittest.TestCase):
         with self.assertRaises(MediaError) as raised:
             validate_reference_durations([], clip("video", 15.11))
         self.assertEqual(raised.exception.code, "UNSUPPORTED_DURATION")
+
+
+class WorkflowMaterializationTests(unittest.TestCase):
+    @staticmethod
+    def plan(**overrides):
+        value = {
+            "kind": "image_scale_to_total_pixels_x",
+            "version": 1,
+            "node_class": "ImageScaleToTotalPixelsX",
+            "contract_sha": "79e831097bb7a76ade3a28359300e62332086c42",
+            "megapixels": 0.70,
+            "multiple_of": 32,
+            "resize_mode": "crop",
+            "upscale_method": "lanczos",
+        }
+        value.update(overrides)
+        return value
+
+    def test_reviewed_lanczos_crop_matches_scale_x_geometry_and_pixels(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "source.png"
+            target = root / "materialized.png"
+            image = Image.new("RGB", (640, 480))
+            pixels = image.load()
+            for y in range(image.height):
+                for x in range(image.width):
+                    pixels[x, y] = (x % 256, y % 256, (x + y) % 256)
+            image.save(source)
+
+            result = materialize_workflow_image(source, target, self.plan())
+            self.assertEqual((result["width"], result["height"]), (960, 704))
+
+            expected = image.resize((960, 720), Image.Resampling.LANCZOS).crop((0, 8, 960, 712))
+            with Image.open(target) as actual:
+                self.assertEqual(actual.size, (960, 704))
+                self.assertIsNone(ImageChops.difference(actual.convert("RGB"), expected).getbbox())
+
+    def test_reviewed_plan_is_strictly_pinned_and_non_lanczos_methods_fail_closed(self):
+        normalized = normalize_workflow_materialization_plan(self.plan(resize_mode="pad"))
+        self.assertEqual(normalized["contract_sha"], "79e831097bb7a76ade3a28359300e62332086c42")
+        with self.assertRaises(MediaError) as raised:
+            normalize_workflow_materialization_plan(self.plan(contract_sha="changed"))
+        self.assertEqual(raised.exception.code, "WORKFLOW_MATERIALIZATION_CONTRACT_DRIFT")
+        with self.assertRaises(MediaError) as raised:
+            normalize_workflow_materialization_plan(self.plan(upscale_method="bicubic"))
+        self.assertEqual(raised.exception.code, "WORKFLOW_MATERIALIZATION_UNSUPPORTED")
 
 
 if __name__ == "__main__":

--- a/tests/test_prompt_audit.py
+++ b/tests/test_prompt_audit.py
@@ -1,6 +1,9 @@
 import unittest
 
+from backend.h3_pipeline import _audit, validate_media_capabilities
 from backend.prompt_audit import audit_prompt
+from backend.models.contract import ModelError
+from backend.prompt_repair import continuum_chunk_repair_messages
 
 
 def reference_prompt(word_count: int, *, include_soundscape: bool = True) -> str:
@@ -102,6 +105,158 @@ class PromptAuditTests(unittest.TestCase):
         self.assertTrue(result["missing_shot_marker"])
         self.assertTrue(result["repair_required"])
 
+
+    def test_text_only_direct_allows_workflow_only_continuum_conditioning(self):
+        model = {
+            "family": "gguf",
+            "capabilities": {"images": False, "video_frames": False},
+        }
+        assembled = {
+            "input": {
+                "mode": "FL2VA",
+                "generation_target": "continuum",
+            },
+            "media_inputs": [],
+        }
+        validate_media_capabilities(model, assembled)
+
+    def test_text_only_direct_rejects_prompt_writer_visual_analysis_for_continuum(self):
+        model = {
+            "family": "gguf",
+            "capabilities": {"images": False, "video_frames": False},
+        }
+        assembled = {
+            "input": {
+                "mode": "FL2VA",
+                "generation_target": "continuum",
+            },
+            "media_inputs": [
+                {"type": "image", "requires_capability": "images"},
+            ],
+        }
+        with self.assertRaises(ModelError) as raised:
+            validate_media_capabilities(model, assembled)
+        self.assertEqual(raised.exception.code, "DIRECT_VISION_REQUIRED")
+
+    def test_continuum_planner_internal_t2va_marker_does_not_bypass_visual_requirement(self):
+        model = {
+            "family": "gguf",
+            "capabilities": {"images": False, "video_frames": False},
+        }
+        assembled = {
+            "input": {
+                "mode": "T2VA",
+                "underlying_mode": "FL2VA",
+                "generation_target": "continuum",
+            },
+            "media_inputs": [
+                {"type": "image", "requires_capability": "images"},
+            ],
+        }
+        with self.assertRaises(ModelError) as raised:
+            validate_media_capabilities(model, assembled)
+        self.assertEqual(raised.exception.code, "DIRECT_VISION_REQUIRED")
+        self.assertEqual(raised.exception.details["mode"], "FL2VA")
+
+    def test_continuum_reference_chunk_skips_standalone_reference_structure_audit(self):
+        assembled = {
+            "input": {
+                "mode": "Reference",
+                "generation_target": "continuum",
+                "continuum_stage": "chunk",
+                "continuum_chunk_allowed_references": ["<Picture 1>"],
+                "continuum_plan": {
+                    "global": {"sequence_preamble": "Keep <Picture 1> identity consistent."}
+                },
+                "creative_brief": "Keep <Picture 1> consistent.",
+                "duration_seconds": 5,
+            }
+        }
+        result, policy, _intent, _duration, _camera = _audit(
+            "The subject continues walking while the camera tracks beside them.",
+            assembled,
+        )
+        self.assertIsNone(result["official_format_pass"])
+        self.assertEqual(result["reference_understanding"], "continuum_timeline_chunk")
+        self.assertNotIn("missing_sections", result)
+        self.assertEqual(policy.allowed, {"<Picture 1>"})
+
+    def test_continuum_chunk_repair_contract_preserves_chunk_shape_and_exact_tag_scope(self):
+        assembled = {
+            "messages": [
+                {"role": "system", "content": "Continuum chunk system."},
+                {"role": "user", "content": "Write Chunk 2 only."},
+            ]
+        }
+        messages = continuum_chunk_repair_messages(
+            assembled,
+            "Reset to <Picture 1>.",
+            ["unexpected reference tags: <Picture 1>"],
+            set(),
+            set(),
+        )
+        system = messages[0]["content"]
+        self.assertIn("Continuum Timeline chunk body", system)
+        self.assertIn("Do not add a shared preamble, Timeline header", system)
+        self.assertIn("standalone I2VA/FL2VA/L2VA alignment line", system)
+        self.assertIn("must remain in this chunk body are: none", system)
+        self.assertIn("permitted in this chunk are: none", system)
+        self.assertIn("Reset to <Picture 1>.", messages[1]["content"])
+
+    def test_continuum_chunk_audit_repairs_standalone_wrapper_or_repeated_preamble(self):
+        assembled = {
+            "input": {
+                "mode": "FL2VA",
+                "generation_target": "continuum",
+                "continuum_stage": "chunk",
+                "continuum_chunk_allowed_references": [],
+                "continuum_plan": {
+                    "global": {
+                        "sequence_preamble": "Stable identity and camera language."
+                    }
+                },
+                "creative_brief": "Continue the same scene.",
+                "duration_seconds": 5,
+            }
+        }
+        result, _policy, _intent, _duration, _camera = _audit(
+            "Stable identity and camera language.\n\nintegrated_multimodal_description: [Shot 1] Continue.",
+            assembled,
+        )
+        self.assertTrue(result["repair_required"])
+        self.assertIn(
+            "repeated shared sequence preamble",
+            result["format_violations"],
+        )
+        self.assertTrue(
+            any(
+                item.startswith("standalone H3 field labels:")
+                for item in result["format_violations"]
+            )
+        )
+        self.assertIn(
+            "standalone [Shot N] wrapper",
+            result["format_violations"],
+        )
+
+    def test_continuum_chunk_audit_still_reports_out_of_scope_reference_tags(self):
+        assembled = {
+            "input": {
+                "mode": "Reference",
+                "generation_target": "continuum",
+                "continuum_stage": "chunk",
+                "continuum_chunk_allowed_references": [],
+                "continuum_plan": {"global": {"sequence_preamble": "Stable scene."}},
+                "creative_brief": "Continue the scene.",
+                "duration_seconds": 5,
+            }
+        }
+        result, _policy, _intent, _duration, _camera = _audit(
+            "Reset to <Picture 1>.",
+            assembled,
+        )
+        self.assertEqual(result["unexpected_reference_tags"], ["<Picture 1>"])
+        self.assertTrue(result["repair_required"])
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_routes_stability.py
+++ b/tests/test_routes_stability.py
@@ -1,4 +1,5 @@
 import asyncio
+import io
 import json
 import sys
 import tempfile
@@ -7,6 +8,8 @@ import types
 import unittest
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
+
+from PIL import Image
 
 
 class _FakeRoutes:
@@ -21,6 +24,7 @@ sys.modules["server"] = types.SimpleNamespace(
     PromptServer=types.SimpleNamespace(instance=types.SimpleNamespace(routes=_FakeRoutes()))
 )
 
+from backend import media as media_module  # noqa: E402
 from backend import routes  # noqa: E402
 
 
@@ -159,6 +163,40 @@ class RouteStabilityTests(unittest.IsolatedAsyncioTestCase):
             "loaded_models": None,
         })
         self.assertEqual(payload["prompt_residency"]["ollama"]["targets"], targets)
+
+    async def test_workflow_materialization_route_commits_exact_scaled_reference_media(self):
+        image = Image.new("RGB", (640, 480), (96, 128, 160))
+        payload = io.BytesIO()
+        image.save(payload, "PNG")
+        plan = {
+            "kind": "image_scale_to_total_pixels_x",
+            "version": 1,
+            "node_class": "ImageScaleToTotalPixelsX",
+            "contract_sha": "79e831097bb7a76ade3a28359300e62332086c42",
+            "megapixels": 0.70,
+            "multiple_of": 32,
+            "resize_mode": "crop",
+            "upscale_method": "lanczos",
+        }
+        fields = [
+            _MultipartField("session_id", text=self.session_id),
+            _MultipartField("mode", text="Reference"),
+            _MultipartField("materialization_plan", text=json.dumps(plan)),
+            _MultipartField("file", filename="source.png", content=payload.getvalue(), content_type="image/png"),
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            store = media_module.MediaStore()
+            with (
+                patch.object(routes, "CACHE_ROOT", Path(directory)),
+                patch.object(routes, "STORE", store),
+            ):
+                response = await routes.materialize_workflow_reference_media(_MultipartRequest(fields))
+                body = self.payload(response)
+
+        self.assertEqual(response.status, 201)
+        self.assertEqual(len(body["assets"]), 1)
+        self.assertEqual((body["assets"][0]["width"], body["assets"][0]["height"]), (960, 704))
+        self.assertEqual(body["assets"][0]["type"], "image")
 
     async def test_ollama_resolution_passes_the_selected_host_to_detection_and_inference(self):
         host = "http://192.168.1.20:11434"

--- a/tests/test_scale_image_total_pixels_x_cross_repo.py
+++ b/tests/test_scale_image_total_pixels_x_cross_repo.py
@@ -1,0 +1,45 @@
+import os
+from pathlib import Path
+import unittest
+
+
+class ScaleImageToTotalPixelsXCrossRepositoryContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        raw = os.environ.get("SCALE_IMAGE_TOTAL_PIXELS_X_SOURCE", "").strip()
+        if not raw:
+            raise unittest.SkipTest("SCALE_IMAGE_TOTAL_PIXELS_X_SOURCE is not set")
+        cls.source = (Path(raw) / "__init__.py").read_text("utf-8")
+
+    def test_reviewed_node_identity_and_public_controls_are_pinned(self):
+        for token in (
+            "class ImageScaleToTotalPixelsX:",
+            '"ImageScaleToTotalPixelsX": ImageScaleToTotalPixelsX',
+            '"megapixels"',
+            '"multiple_of"',
+            '"resize_mode"',
+            '"upscale_method"',
+            '"stretch"',
+            '"crop"',
+            '"pad"',
+            '"lanczos"',
+        ):
+            self.assertIn(token, self.source)
+
+    def test_reviewed_geometry_and_lanczos_contract_matches_materializer(self):
+        for token in (
+            "total = int(megapixels * 1000000)",
+            "scale_by = math.sqrt(total / (ow * oh))",
+            "target_width = target_width - (target_width % multiple_of)",
+            "target_height = target_height - (target_height % multiple_of)",
+            "ratio = max(target_width / ow, target_height / oh)",
+            "x = (new_width - target_width) // 2",
+            "y = (new_height - target_height) // 2",
+            "comfy.utils.lanczos(samples, resize_width, resize_height)",
+            "outputs = outputs[:, y:y2, x:x2, :]",
+        ):
+            self.assertIn(token, self.source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/api/h3studio.js
+++ b/web/api/h3studio.js
@@ -47,6 +47,42 @@ export async function freeComfyVram() {
   }
 }
 
+export async function fetchComfyImageFile(source, filenameOverride = null) {
+  const filename = String(source?.filename ?? "").trim();
+  const subfolder = String(source?.subfolder ?? "").trim();
+  const type = String(source?.type ?? "input").trim().toLowerCase();
+  if (!filename || filename.includes("/") || !["input", "output", "temp"].includes(type)) {
+    const error = new Error("The workflow image source cannot be resolved through ComfyUI's image view endpoint.");
+    error.code = "WORKFLOW_REFERENCE_UNAVAILABLE";
+    throw error;
+  }
+  const query = new URLSearchParams({ filename, subfolder, type });
+  const response = await api.fetchApi(`/view?${query.toString()}`);
+  if (!response.ok) {
+    const error = new Error(`ComfyUI could not read workflow image ${filename} (${response.status}).`);
+    error.code = "WORKFLOW_REFERENCE_READ_FAILED";
+    throw error;
+  }
+  const blob = await response.blob();
+  const contentType = blob.type || response.headers.get("content-type") || "image/png";
+  if (!contentType.startsWith("image/")) {
+    const error = new Error(`Workflow source ${filename} did not resolve to an image.`);
+    error.code = "WORKFLOW_REFERENCE_READ_FAILED";
+    throw error;
+  }
+  return new File([blob], filenameOverride || filename, { type: contentType });
+}
+
+export function materializeWorkflowImage(sessionId, mode, file, plan, replaceAssetId = null) {
+  const body = new FormData();
+  body.append("session_id", sessionId);
+  body.append("mode", mode);
+  body.append("materialization_plan", JSON.stringify(plan));
+  body.append("file", file);
+  const replace = replaceAssetId ? `?replace_asset_id=${encodeURIComponent(replaceAssetId)}` : "";
+  return request(`/media/materialize-workflow-image${replace}`, { method: "POST", body });
+}
+
 export function uploadMedia(sessionId, mode, files, replaceAssetId = null) {
   const body = new FormData();
   body.append("session_id", sessionId);

--- a/web/continuum.js
+++ b/web/continuum.js
@@ -1,0 +1,1404 @@
+export const CONTINUUM_SCHEMA_VERSION = 2;
+export const LEGACY_CONTINUUM_SCHEMA_VERSION = 1;
+export const CONTINUUM_MIN_CHUNKS = 1;
+export const CONTINUUM_MAX_CHUNKS = 16;
+export const CONTINUUM_MIN_SECONDS = 4;
+export const CONTINUUM_MAX_SECONDS = 30;
+export const CONTINUUM_SAMPLER_NODE_IDS = new Set([
+  "H3ContinuumSamplerV34",
+  "H3ContinuumSamplerV35",
+  "H3ContinuumSamplerV36",
+  "H3ContinuumSamplerV37",
+]);
+export const CONTINUUM_PROMPT_MODE = "Timeline";
+
+const LEGACY_CHUNK_HEADER = /^\s*\[\s*Chunk\s+(\d+)\s*\]\s*$/i;
+const TIMELINE_HEADER = /^\s*\[\s*(\d+(?:\.\d+)?)\s*-\s*(\d+(?:\.\d+)?)\s*s?\s*\]\s*$/i;
+const EDITABLE_MULTILINE_NODE_IDS = new Set(["PrimitiveStringMultiline"]);
+const CONTINUUM_REFERENCE_INPUTS = Array.from({ length: 8 }, (_, offset) => `reference_image_${offset + 1}`);
+const CONDITIONING_ROLES = new Map([
+  ["first_frame", { role: "first_frame", kind: "image" }],
+  ["last_frame", { role: "last_frame", kind: "image" }],
+  ["reference_video_1", { role: "video_reference", kind: "video" }],
+  ["reference_audio_1", { role: "reference_audio", kind: "audio" }],
+  ["driving_audio", { role: "driving_audio", kind: "audio" }],
+]);
+
+export function normalizeContinuumSettings(value = {}) {
+  const chunks = Number(value.chunks);
+  const chunkSeconds = Number(value.chunk_seconds ?? value.chunkSeconds);
+  if (!Number.isInteger(chunks) || chunks < CONTINUUM_MIN_CHUNKS || chunks > CONTINUUM_MAX_CHUNKS) {
+    throw new Error(`Continuum chunks must be between ${CONTINUUM_MIN_CHUNKS} and ${CONTINUUM_MAX_CHUNKS}.`);
+  }
+  if (!Number.isFinite(chunkSeconds) || chunkSeconds < CONTINUUM_MIN_SECONDS || chunkSeconds > CONTINUUM_MAX_SECONDS) {
+    throw new Error(`Continuum chunk duration must be between ${CONTINUUM_MIN_SECONDS} and ${CONTINUUM_MAX_SECONDS} seconds.`);
+  }
+  return {
+    schema_version: CONTINUUM_SCHEMA_VERSION,
+    chunks,
+    chunk_seconds: chunkSeconds,
+    total_seconds: Number((chunks * chunkSeconds).toFixed(12)),
+  };
+}
+
+function decimalParts(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number < 0) throw new Error("Continuum timeline value must be finite and non-negative.");
+  let text = String(number);
+  if (/e/i.test(text)) {
+    text = number.toFixed(12).replace(/0+$/, "").replace(/\.$/, "");
+  }
+  if (!/^\d+(?:\.\d+)?$/.test(text)) throw new Error("Continuum timeline value cannot be represented canonically.");
+  const [whole, fraction = ""] = text.split(".");
+  const scale = 10n ** BigInt(fraction.length);
+  const units = BigInt(whole + fraction);
+  return { units, scale, digits: fraction.length };
+}
+
+function formatScaledUnits(units, scale, digits) {
+  if (digits === 0) return String(units);
+  const whole = units / scale;
+  const fractionUnits = units % scale;
+  let fraction = fractionUnits.toString().padStart(digits, "0").replace(/0+$/, "");
+  return fraction ? `${whole}.${fraction}` : String(whole);
+}
+
+export function timelineBoundary(chunkSeconds, index) {
+  if (!Number.isInteger(index) || index < 0) throw new Error("Continuum timeline boundary index must be non-negative.");
+  const { units, scale, digits } = decimalParts(chunkSeconds);
+  if (units <= 0n) throw new Error("Continuum chunk duration must be positive.");
+  return formatScaledUnits(units * BigInt(index), scale, digits);
+}
+
+function containsReservedHeader(value) {
+  return String(value).split(/\r?\n/).some((line) => LEGACY_CHUNK_HEADER.test(line) || TIMELINE_HEADER.test(line));
+}
+
+function normalizePrompts(prompts) {
+  if (!Array.isArray(prompts) || prompts.length === 0) throw new Error("A Continuum sequence needs at least one chunk.");
+  return prompts.map((prompt, offset) => {
+    const value = typeof prompt === "string" ? prompt.trim() : "";
+    if (!value) throw new Error(`Chunk ${offset + 1} prompt is empty.`);
+    if (containsReservedHeader(value)) throw new Error(`Chunk ${offset + 1} contains a reserved Continuum section header.`);
+    return value;
+  });
+}
+
+export function serializeContinuumPrompts(prompts, { preamble = "", chunkSeconds = 5 } = {}) {
+  const bodies = normalizePrompts(prompts);
+  const shared = typeof preamble === "string" ? preamble.trim() : "";
+  if (shared && containsReservedHeader(shared)) throw new Error("Continuum shared preamble contains a reserved section header.");
+  const sections = bodies.map((body, offset) => (
+    `[${timelineBoundary(chunkSeconds, offset)}-${timelineBoundary(chunkSeconds, offset + 1)}s]\n${body}`
+  ));
+  return shared ? `${shared}\n\n${sections.join("\n\n")}` : sections.join("\n\n");
+}
+
+export function parseContinuumTimeline(script, { expectedChunks, chunkSeconds } = {}) {
+  if (typeof script !== "string" || !script.trim()) throw new Error("Continuum sequence text is empty.");
+  const chunks = Number(expectedChunks);
+  if (!Number.isInteger(chunks) || chunks < 1) throw new Error("Expected Continuum chunk count is required.");
+  const seconds = Number(chunkSeconds);
+  if (!Number.isFinite(seconds) || seconds <= 0) throw new Error("Expected Continuum chunk duration is required.");
+
+  const preambleLines = [];
+  const prompts = [];
+  let body = [];
+  let currentIndex = null;
+
+  const finish = () => {
+    if (currentIndex == null) return;
+    const prompt = body.join("\n").trim();
+    if (!prompt) throw new Error(`Timeline section ${currentIndex + 1} prompt is empty.`);
+    prompts.push(prompt);
+    body = [];
+  };
+
+  script.split(/\r?\n/).forEach((line, offset) => {
+    const match = line.match(TIMELINE_HEADER);
+    if (match) {
+      finish();
+      const nextIndex = currentIndex == null ? 0 : currentIndex + 1;
+      if (nextIndex >= chunks) throw new Error(`Line ${offset + 1}: too many Timeline sections.`);
+      const expectedHeader = `[${timelineBoundary(seconds, nextIndex)}-${timelineBoundary(seconds, nextIndex + 1)}s]`;
+      const actualStart = Number(match[1]);
+      const actualEnd = Number(match[2]);
+      const expectedStart = Number(timelineBoundary(seconds, nextIndex));
+      const expectedEnd = Number(timelineBoundary(seconds, nextIndex + 1));
+      if (actualStart !== expectedStart || actualEnd !== expectedEnd || line.trim() !== expectedHeader) {
+        throw new Error(`Line ${offset + 1}: expected ${expectedHeader}, found ${line.trim()}.`);
+      }
+      currentIndex = nextIndex;
+      return;
+    }
+    if (currentIndex == null) {
+      if (LEGACY_CHUNK_HEADER.test(line)) throw new Error("Legacy [Chunk N] syntax is not canonical Continuum Timeline syntax.");
+      preambleLines.push(line);
+      return;
+    }
+    if (LEGACY_CHUNK_HEADER.test(line)) throw new Error("Legacy [Chunk N] syntax cannot appear inside a Timeline sequence.");
+    body.push(line);
+  });
+  finish();
+
+  if (currentIndex == null) throw new Error("No canonical [start-end] Timeline sections were found.");
+  if (prompts.length !== chunks) throw new Error(`Expected ${chunks} Timeline sections, found ${prompts.length}.`);
+  const preamble = preambleLines.join("\n").trim();
+  const canonical = serializeContinuumPrompts(prompts, { preamble, chunkSeconds: seconds });
+  if (canonical !== script.trim()) throw new Error("Continuum Timeline contains non-canonical whitespace or header formatting.");
+  return { preamble, prompts };
+}
+
+export function parseContinuumPrompts(script, expectedChunks = null, chunkSeconds = 5) {
+  if (expectedChunks == null) throw new Error("Expected Continuum chunk count is required.");
+  return parseContinuumTimeline(script, { expectedChunks, chunkSeconds }).prompts;
+}
+
+function parseLegacyChunkPrompts(script, expectedChunks = null) {
+  if (typeof script !== "string" || !script.trim()) throw new Error("Legacy Continuum sequence text is empty.");
+  const prompts = [];
+  let currentIndex = null;
+  let body = [];
+  const finish = () => {
+    if (currentIndex == null) {
+      if (body.some((line) => line.trim())) throw new Error("Legacy migration rejects text before [Chunk 1].");
+      body = [];
+      return;
+    }
+    const prompt = body.join("\n").trim();
+    if (!prompt) throw new Error(`Legacy Chunk ${currentIndex} prompt is empty.`);
+    prompts.push(prompt);
+    body = [];
+  };
+  script.split(/\r?\n/).forEach((line, offset) => {
+    if (TIMELINE_HEADER.test(line)) throw new Error("Legacy migration cannot mix Timeline and [Chunk N] sections.");
+    const match = line.match(LEGACY_CHUNK_HEADER);
+    if (!match) {
+      body.push(line);
+      return;
+    }
+    finish();
+    const index = Number(match[1]);
+    const expected = prompts.length + 1;
+    if (index !== expected) throw new Error(`Line ${offset + 1}: expected [Chunk ${expected}], found [Chunk ${index}].`);
+    currentIndex = index;
+  });
+  finish();
+  if (!prompts.length) throw new Error("No legacy [Chunk N] sections were found.");
+  if (expectedChunks != null && prompts.length !== expectedChunks) {
+    throw new Error(`Expected ${expectedChunks} legacy chunks, found ${prompts.length}.`);
+  }
+  return prompts;
+}
+
+function inventoryIdentityItem(item = {}) {
+  return {
+    role: item.role == null ? null : String(item.role),
+    kind: item.kind == null ? null : String(item.kind),
+    source: item.source == null ? null : String(item.source),
+    visible_to_model: Boolean(item.visible_to_model),
+    tag: item.tag == null ? null : String(item.tag),
+    input_name: item.input_name == null ? null : String(item.input_name),
+    source_node_id: item.source_node_id == null ? null : String(item.source_node_id),
+    source_node_class: item.source_node_class == null ? null : String(item.source_node_class),
+    source_output_name: item.source_output_name == null ? null : String(item.source_output_name),
+    source_slot: Number.isInteger(item.source_slot) ? item.source_slot : null,
+    source_identity: item.source_identity == null ? null : String(item.source_identity),
+    model_asset_id: item.model_asset_id == null ? null : String(item.model_asset_id),
+  };
+}
+
+export function continuumInventoryIdentity(inventory) {
+  const items = Array.isArray(inventory?.items) ? inventory.items : [];
+  return {
+    schema_version: Number(inventory?.schema_version ?? 1),
+    items: items.map(inventoryIdentityItem),
+  };
+}
+
+export function sameContinuumReferenceInventory(savedInventory, activeInventory) {
+  const saved = continuumInventoryIdentity(savedInventory);
+  const active = continuumInventoryIdentity(activeInventory);
+  if (saved.schema_version !== active.schema_version || saved.items.length !== active.items.length) return false;
+
+  return saved.items.every((savedValue, index) => {
+    const activeValue = active.items[index];
+    if (
+      Boolean(savedValue.model_asset_id) !== savedValue.visible_to_model
+      || Boolean(activeValue.model_asset_id) !== activeValue.visible_to_model
+    ) return false;
+
+    const savedSourceIdentity = savedValue.source_identity;
+    const activeSourceIdentity = activeValue.source_identity;
+    const savedModelAssetId = savedValue.model_asset_id;
+    const activeModelAssetId = activeValue.model_asset_id;
+
+    const savedItem = { ...savedValue, source_identity: null, model_asset_id: null };
+    const activeItem = { ...activeValue, source_identity: null, model_asset_id: null };
+    if (JSON.stringify(savedItem) !== JSON.stringify(activeItem)) return false;
+
+    // Inventories saved before source_identity existed use null as an unknown
+    // legacy identity. Once a saved fingerprint exists, it must match strictly.
+    if (savedSourceIdentity != null && savedSourceIdentity !== activeSourceIdentity) return false;
+
+    // model_asset_id is a temporary Writer-session handle. A different ID is
+    // safe only when a stable saved workflow fingerprint proves both copies
+    // came from the same downstream source.
+    if (
+      savedModelAssetId !== activeModelAssetId
+      && (savedSourceIdentity == null || savedSourceIdentity !== activeSourceIdentity)
+    ) return false;
+    return true;
+  });
+}
+
+
+export function sequenceStateFromResult(result) {
+  const sequence = result?.sequence;
+  const settings = normalizeContinuumSettings(sequence?.settings || {});
+  if (sequence?.schema_version !== CONTINUUM_SCHEMA_VERSION || !sequence?.plan || !Array.isArray(sequence?.chunks)) {
+    throw new Error("The generated Continuum response has no valid structural sequence state.");
+  }
+  const preamble = typeof sequence?.preamble === "string" ? sequence.preamble.trim() : "";
+  const prompts = sequence.chunks.map((chunk, offset) => {
+    const body = typeof chunk?.body === "string" ? chunk.body : chunk?.prompt;
+    if (chunk?.index !== offset + 1 || typeof body !== "string" || !body.trim()) {
+      throw new Error(`Generated Continuum Chunk ${offset + 1} is invalid.`);
+    }
+    return body.trim();
+  });
+  if (prompts.length !== settings.chunks) throw new Error("Generated Continuum chunk count does not match its settings.");
+  const prompt = serializeContinuumPrompts(prompts, { preamble, chunkSeconds: settings.chunk_seconds });
+  if (prompt !== result.prompt) throw new Error("Generated Continuum canonical Timeline text does not match its structural state.");
+  const downstreamReferenceInventory = sequence?.downstream_reference_inventory ?? null;
+  if (
+    downstreamReferenceInventory != null
+    && (!Array.isArray(downstreamReferenceInventory?.items) || Number(downstreamReferenceInventory?.schema_version ?? 1) !== 1)
+  ) {
+    throw new Error("Generated Continuum response has an invalid downstream conditioning inventory snapshot.");
+  }
+  return {
+    schema_version: CONTINUUM_SCHEMA_VERSION,
+    settings,
+    plan: sequence.plan,
+    preamble,
+    prompts,
+    downstream_reference_inventory: downstreamReferenceInventory,
+  };
+}
+
+export function continuumDraftOutput(value) {
+  if (value?.raw_prompt != null) return String(value.raw_prompt);
+  const settings = normalizeContinuumSettings(value?.settings || {});
+  const preamble = typeof value?.preamble === "string"
+    ? value.preamble
+    : typeof value?.plan?.global?.sequence_preamble === "string"
+      ? value.plan.global.sequence_preamble
+      : "";
+  return serializeContinuumPrompts(value?.prompts || [], { preamble, chunkSeconds: settings.chunk_seconds });
+}
+
+export function updateContinuumDraftFromEditor(value, script) {
+  const settings = normalizeContinuumSettings(value?.settings || {});
+  try {
+    const parsed = parseContinuumTimeline(script, {
+      expectedChunks: settings.chunks,
+      chunkSeconds: settings.chunk_seconds,
+    });
+    return {
+      ...value,
+      schema_version: CONTINUUM_SCHEMA_VERSION,
+      settings,
+      preamble: parsed.preamble,
+      prompts: parsed.prompts,
+      raw_prompt: null,
+    };
+  } catch (timelineError) {
+    const mayMigrateLegacy = value?.schema_version === LEGACY_CONTINUUM_SCHEMA_VERSION
+      || value?.migrated_from_schema_version === LEGACY_CONTINUUM_SCHEMA_VERSION
+      || !value?.schema_version;
+    if (mayMigrateLegacy) {
+      try {
+        const prompts = parseLegacyChunkPrompts(script, settings.chunks);
+        return {
+          ...value,
+          schema_version: CONTINUUM_SCHEMA_VERSION,
+          settings,
+          preamble: "",
+          prompts,
+          raw_prompt: null,
+          migrated_from_schema_version: LEGACY_CONTINUUM_SCHEMA_VERSION,
+        };
+      } catch {
+        // Keep malformed manual text verbatim. It cannot be applied until corrected.
+      }
+    }
+    return {
+      ...value,
+      schema_version: CONTINUUM_SCHEMA_VERSION,
+      settings,
+      raw_prompt: String(script),
+      timeline_error: String(timelineError?.message || timelineError),
+    };
+  }
+}
+
+function nodeClassId(node) {
+  return node?.comfyClass || node?.type || node?.properties?.["Node name for S&R"] || "";
+}
+
+function inputNames(node) {
+  return new Set((node?.inputs || []).map((input) => input?.name));
+}
+
+function widget(node, name) {
+  return (node?.widgets || []).find((candidate) => candidate?.name === name) || null;
+}
+
+export function isCompatibleContinuumSampler(node) {
+  if (!CONTINUUM_SAMPLER_NODE_IDS.has(nodeClassId(node))) return false;
+  const inputs = inputNames(node);
+  return (
+    inputs.has("sequence_prompt")
+    && widget(node, "prompt_mode") != null
+    && widget(node, "chunks") != null
+    && widget(node, "chunk_seconds") != null
+  );
+}
+
+export function compatibleContinuumSamplers(graph) {
+  return (graph?._nodes || []).filter(isCompatibleContinuumSampler);
+}
+
+function selectedNodes(canvas) {
+  const selected = canvas?.selected_nodes ?? canvas?.selectedItems;
+  if (selected instanceof Map) return [...selected.values()];
+  if (Array.isArray(selected)) return selected;
+  if (selected && typeof selected === "object") return Object.values(selected);
+  return [];
+}
+
+export function chooseContinuumSampler(app) {
+  const candidates = compatibleContinuumSamplers(app?.graph);
+  if (!candidates.length) return { status: "missing", candidates };
+  if (candidates.length === 1) return { status: "selected", sampler: candidates[0], candidates };
+  const selected = selectedNodes(app?.canvas).filter((node) => candidates.includes(node));
+  if (selected.length === 1) return { status: "selected", sampler: selected[0], candidates };
+  return { status: "multiple", candidates };
+}
+
+function graphLink(graph, linkId) {
+  if (linkId == null) return null;
+  if (graph?.links instanceof Map) return graph.links.get(linkId) || null;
+  return graph?.links?.[linkId] || null;
+}
+
+function graphNode(graph, nodeId) {
+  return graph?.getNodeById?.(nodeId) || (graph?._nodes || []).find((node) => node?.id === nodeId) || null;
+}
+
+const NODE_MODE_NEVER = 2;
+const NODE_MODE_BYPASS = 4;
+
+const IMAGE_CONVEYOR_NODE_IDS = new Set(["ImageConveyor", "SequentialBatchImageLoader"]);
+const IMAGE_CONVEYOR_OUTPUT_MODE_PERSISTENT = "persistent_refs";
+const IMAGE_CONVEYOR_OUTPUT_MODE_QUEUE_GROUP = "queue_group";
+const IMAGE_CONVEYOR_REFERENCE_SLOTS = 8;
+const IMAGE_CONVEYOR_MAX_GROUP_IMAGES = 9;
+const IMAGE_CONVEYOR_REFERENCE_OUTPUT_START = 6;
+const IMAGE_CONVEYOR_LAST_FRAME_OUTPUT = 14;
+const IMAGE_CONVEYOR_REFERENCE_PROPERTY = "image_conveyor_reference_enabled";
+const IMAGE_CONVEYOR_MAIN_PROPERTY = "image_conveyor_main_enabled";
+const IMAGE_CONVEYOR_LAST_FRAME_PROPERTY = "image_conveyor_last_frame_enabled";
+const SCALE_IMAGE_TOTAL_PIXELS_X_NODE_CLASS = "ImageScaleToTotalPixelsX";
+const SCALE_IMAGE_TOTAL_PIXELS_X_CONTRACT_SHA = "79e831097bb7a76ade3a28359300e62332086c42";
+const SCALE_IMAGE_TOTAL_PIXELS_X_PLAN_VERSION = 1;
+
+function jsonObject(value) {
+  if (typeof value !== "string" || !value.trim()) return null;
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function imageConveyorState(node) {
+  const serialized = jsonObject(widget(node, "state_json")?.value);
+  const live = node?.__bil?.state;
+  const liveState = live && typeof live === "object" && !Array.isArray(live) ? live : null;
+  if (!serialized && !liveState) {
+    throw new Error(`Image Conveyor ${String(node?.id ?? "")} has no readable state_json; Continuum reference topology cannot be resolved safely.`);
+  }
+  return { ...(serialized || {}), ...(liveState || {}) };
+}
+
+function normalizedConveyorGroupSize(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return 1;
+  return Math.max(1, Math.min(IMAGE_CONVEYOR_MAX_GROUP_IMAGES, Math.trunc(number)));
+}
+
+function imageConveyorOutputMode(state) {
+  if (Object.hasOwn(state, "output_mode")) {
+    return String(state.output_mode ?? "").trim().toLowerCase() === IMAGE_CONVEYOR_OUTPUT_MODE_QUEUE_GROUP
+      ? IMAGE_CONVEYOR_OUTPUT_MODE_QUEUE_GROUP
+      : IMAGE_CONVEYOR_OUTPUT_MODE_PERSISTENT;
+  }
+  return normalizedConveyorGroupSize(state.images_per_execution) > 1
+    ? IMAGE_CONVEYOR_OUTPUT_MODE_QUEUE_GROUP
+    : IMAGE_CONVEYOR_OUTPUT_MODE_PERSISTENT;
+}
+
+function explicitConveyorToggle(node, state, propertyName, stateName) {
+  if (node?.properties && Object.hasOwn(node.properties, propertyName)) {
+    return node.properties[propertyName] !== false;
+  }
+  if (Object.hasOwn(state, stateName)) return state[stateName] !== false;
+  return true;
+}
+
+function imageConveyorReferenceEnabled(node, state, index) {
+  const propertyMask = node?.properties?.[IMAGE_CONVEYOR_REFERENCE_PROPERTY];
+  const stateMask = state.reference_output_enabled;
+  const mask = Array.isArray(propertyMask) ? propertyMask : Array.isArray(stateMask) ? stateMask : null;
+  return mask?.[index] !== false;
+}
+
+function imageConveyorOutputName(connection) {
+  const explicit = String(connection?.output?.name ?? connection?.output?.label ?? "").trim();
+  if (explicit) return explicit;
+  const slot = Number(connection?.link?.origin_slot);
+  if (slot === 0) return "image";
+  if (slot >= IMAGE_CONVEYOR_REFERENCE_OUTPUT_START && slot < IMAGE_CONVEYOR_REFERENCE_OUTPUT_START + IMAGE_CONVEYOR_REFERENCE_SLOTS) {
+    return `ref_image_${slot - IMAGE_CONVEYOR_REFERENCE_OUTPUT_START + 1}`;
+  }
+  if (slot === IMAGE_CONVEYOR_LAST_FRAME_OUTPUT) return "last_frame";
+  return "";
+}
+
+function imageConveyorReferenceOutputIndex(outputName) {
+  const match = /^ref_image_([1-8])$/.exec(outputName);
+  return match ? Number(match[1]) - 1 : -1;
+}
+
+function imageConveyorOutputIsActive(connection) {
+  const node = connection?.source;
+  if (!IMAGE_CONVEYOR_NODE_IDS.has(nodeClassId(node))) return true;
+
+  const state = imageConveyorState(node);
+  const mode = imageConveyorOutputMode(state);
+  const outputName = imageConveyorOutputName(connection);
+  const referenceIndex = imageConveyorReferenceOutputIndex(outputName);
+
+  if (mode === IMAGE_CONVEYOR_OUTPUT_MODE_QUEUE_GROUP) {
+    const count = normalizedConveyorGroupSize(state.images_per_execution);
+    if (outputName === "image") return count >= 1;
+    if (outputName === "last_frame") return count >= 2;
+    if (referenceIndex >= 0) return referenceIndex + 2 <= count;
+    return true;
+  }
+
+  if (outputName === "image") {
+    return explicitConveyorToggle(node, state, IMAGE_CONVEYOR_MAIN_PROPERTY, "main_output_enabled");
+  }
+  if (outputName === "last_frame") {
+    return explicitConveyorToggle(node, state, IMAGE_CONVEYOR_LAST_FRAME_PROPERTY, "last_frame_output_enabled");
+  }
+  if (referenceIndex >= 0) {
+    if (!imageConveyorReferenceEnabled(node, state, referenceIndex)) return false;
+    const slots = Array.isArray(state.reference_slots) ? state.reference_slots : [];
+    return slots[referenceIndex] != null;
+  }
+  return true;
+}
+
+function imageConveyorOriginForConnection(graph, connection, visited = new Set()) {
+  const source = connection?.source;
+  if (!source) return null;
+  if (IMAGE_CONVEYOR_NODE_IDS.has(nodeClassId(source))) return connection;
+
+  const sourceSlot = Number(connection?.link?.origin_slot);
+  const key = `${String(source.id ?? "")}:${Number.isFinite(sourceSlot) ? sourceSlot : "?"}`;
+  if (visited.has(key)) return null;
+  visited.add(key);
+
+  const outputType = connection?.output?.type ?? "IMAGE";
+  if (!slotTypesCompatible(outputType, "IMAGE")) return null;
+
+  const candidates = (source.inputs || []).filter((input) => (
+    input?.link != null
+    && slotTypesCompatible(input.type, outputType)
+    && slotTypesCompatible(input.type, "IMAGE")
+  ));
+  if (candidates.length !== 1) return null;
+
+  const input = candidates[0];
+  const upstream = resolveSourceConnection(graph, input.link, input.type ?? outputType);
+  if (!upstream) return null;
+  return imageConveyorOriginForConnection(graph, { input, ...upstream }, visited);
+}
+
+function connectionIsEffectivelyActive(graph, connection) {
+  if (!connection) return false;
+  const conveyorOrigin = imageConveyorOriginForConnection(graph, connection);
+  return conveyorOrigin ? imageConveyorOutputIsActive(conveyorOrigin) : true;
+}
+
+function opaqueStateFingerprint(value) {
+  const text = String(value ?? "");
+  let first = (0xdeadbeef ^ text.length) >>> 0;
+  let second = (0x41c6ce57 ^ text.length) >>> 0;
+  for (let index = 0; index < text.length; index += 1) {
+    const code = text.charCodeAt(index);
+    first = Math.imul(first ^ code, 2654435761) >>> 0;
+    second = Math.imul(second ^ code, 1597334677) >>> 0;
+  }
+  first = Math.imul(first ^ (first >>> 16), 2246822507) >>> 0;
+  first ^= Math.imul(second ^ (second >>> 13), 3266489909);
+  second = Math.imul(second ^ (second >>> 16), 2246822507) >>> 0;
+  second ^= Math.imul(first ^ (first >>> 13), 3266489909);
+  return `${(second >>> 0).toString(16).padStart(8, "0")}${(first >>> 0).toString(16).padStart(8, "0")}`;
+}
+
+function imageConveyorSourceIdentityDescriptor(graph, connection) {
+  const conveyorOrigin = imageConveyorOriginForConnection(graph, connection);
+  if (!conveyorOrigin) return {};
+  const state = imageConveyorState(conveyorOrigin.source);
+  if (imageConveyorOutputMode(state) !== IMAGE_CONVEYOR_OUTPUT_MODE_PERSISTENT) return {};
+  const referenceIndex = imageConveyorReferenceOutputIndex(imageConveyorOutputName(conveyorOrigin));
+  if (referenceIndex < 0) return {};
+  const slot = Array.isArray(state.reference_slots) ? state.reference_slots[referenceIndex] : null;
+  if (!slot || typeof slot !== "object" || Array.isArray(slot)) return {};
+  const stableSlot = JSON.stringify([
+    String(slot.annotated ?? ""),
+    String(slot.filename ?? ""),
+    String(slot.subfolder ?? ""),
+    String(slot.type ?? ""),
+  ]);
+  return {
+    source_identity: `image-conveyor-ref-v1:${opaqueStateFingerprint(stableSlot)}`,
+  };
+}
+
+function safeWorkflowPath(value) {
+  const raw = String(value ?? "").trim().replace(/\\/g, "/");
+  if (!raw || raw.startsWith("/") || /^[a-zA-Z]:/.test(raw)) return "";
+  const parts = raw.split("/").filter(Boolean);
+  if (!parts.length || parts.some((part) => part === "." || part === "..")) return "";
+  return parts.join("/");
+}
+
+function normalizedWorkflowImageFile(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const typeValue = String(value.type ?? "input").trim().toLowerCase();
+  const type = ["input", "output", "temp"].includes(typeValue) ? typeValue : "input";
+  let filename = safeWorkflowPath(value.filename);
+  let subfolder = safeWorkflowPath(value.subfolder);
+  const annotated = String(value.annotated ?? "").trim();
+
+  if (!filename && annotated) {
+    const suffix = annotated.match(/ \[(input|output|temp)\]$/i);
+    const annotatedPath = safeWorkflowPath(suffix ? annotated.slice(0, suffix.index) : annotated);
+    if (annotatedPath) {
+      const parts = annotatedPath.split("/");
+      filename = parts.pop() || "";
+      subfolder = parts.join("/");
+    }
+  } else if (filename && filename.includes("/") && !subfolder) {
+    const parts = filename.split("/");
+    filename = parts.pop() || "";
+    subfolder = parts.join("/");
+  }
+  if (!filename || filename.includes("/")) return null;
+  return { filename, subfolder, type };
+}
+
+function directLoadImageWorkflowMedia(connection) {
+  const source = connection?.source;
+  if (nodeClassId(source) !== "LoadImage") return null;
+  const selected = widget(source, "image")?.value;
+  if (typeof selected !== "string" || !selected.trim()) return null;
+  const file = normalizedWorkflowImageFile({ annotated: selected, type: "input" });
+  if (!file) return null;
+  const stableFile = JSON.stringify([file.filename, file.subfolder, file.type]);
+  return {
+    importable: true,
+    source_kind: "load_image",
+    source_label: "Load Image",
+    source_identity: `load-image-v1:${opaqueStateFingerprint(stableFile)}`,
+    file,
+  };
+}
+
+function imageConveyorWorkflowMedia(graph, connection) {
+  const conveyorOrigin = imageConveyorOriginForConnection(graph, connection);
+  if (!conveyorOrigin) return null;
+  const state = imageConveyorState(conveyorOrigin.source);
+  const mode = imageConveyorOutputMode(state);
+  const outputName = imageConveyorOutputName(conveyorOrigin);
+  const referenceIndex = imageConveyorReferenceOutputIndex(outputName);
+
+  if (mode === IMAGE_CONVEYOR_OUTPUT_MODE_QUEUE_GROUP) {
+    return {
+      importable: false,
+      reason: "dynamic_queue_group",
+      source_kind: "image_conveyor_queue_group",
+      source_label: outputName || "Image Conveyor queue output",
+    };
+  }
+  if (referenceIndex < 0) {
+    return {
+      importable: false,
+      reason: "queue_driven_output",
+      source_kind: "image_conveyor_queue_output",
+      source_label: outputName || "Image Conveyor queue output",
+    };
+  }
+
+  const direct = (
+    conveyorOrigin.source === connection.source
+    && Number(conveyorOrigin.link?.origin_slot) === Number(connection.link?.origin_slot)
+  );
+  if (!direct) {
+    return {
+      importable: false,
+      reason: "processed_image_chain",
+      source_kind: "image_conveyor_processed",
+      source_label: `Image Conveyor Ref ${referenceIndex + 1}`,
+    };
+  }
+
+  const slot = Array.isArray(state.reference_slots) ? state.reference_slots[referenceIndex] : null;
+  const file = normalizedWorkflowImageFile(slot);
+  if (!file) {
+    return {
+      importable: false,
+      reason: "unreadable_reference_file",
+      source_kind: "image_conveyor_persistent",
+      source_label: `Image Conveyor Ref ${referenceIndex + 1}`,
+    };
+  }
+  return {
+    importable: true,
+    source_kind: "image_conveyor_persistent",
+    source_label: `Image Conveyor Ref ${referenceIndex + 1}`,
+    source_identity: imageConveyorSourceIdentityDescriptor(graph, connection).source_identity ?? null,
+    file,
+  };
+}
+
+function scaleImageToTotalPixelsXPlan(node) {
+  if (nodeClassId(node) !== SCALE_IMAGE_TOTAL_PIXELS_X_NODE_CLASS) return null;
+  const dynamicParameter = (node?.inputs || []).find((input) => (
+    ["width", "height", "megapixels", "multiple_of", "resize_mode", "upscale_method"].includes(input?.name)
+    && input?.link != null
+  ));
+  if (dynamicParameter) {
+    return {
+      supported: false,
+      reason: "dynamic_transform_parameters",
+      dynamic_parameter: String(dynamicParameter.name),
+    };
+  }
+
+  const megapixels = Number(widget(node, "megapixels")?.value);
+  const multipleOf = Number(widget(node, "multiple_of")?.value);
+  const resizeMode = String(widget(node, "resize_mode")?.value ?? "").trim().toLowerCase();
+  const upscaleMethod = String(widget(node, "upscale_method")?.value ?? "").trim().toLowerCase();
+  if (
+    !Number.isFinite(megapixels)
+    || megapixels < 0
+    || megapixels > 16
+    || !Number.isInteger(multipleOf)
+    || multipleOf < 1
+    || multipleOf > 128
+    || !["stretch", "crop", "pad"].includes(resizeMode)
+  ) {
+    return { supported: false, reason: "unsupported_transform_configuration" };
+  }
+  if (upscaleMethod !== "lanczos") {
+    return { supported: false, reason: "unsupported_transform_method" };
+  }
+  return {
+    supported: true,
+    plan: {
+      kind: "image_scale_to_total_pixels_x",
+      version: SCALE_IMAGE_TOTAL_PIXELS_X_PLAN_VERSION,
+      node_class: SCALE_IMAGE_TOTAL_PIXELS_X_NODE_CLASS,
+      contract_sha: SCALE_IMAGE_TOTAL_PIXELS_X_CONTRACT_SHA,
+      megapixels,
+      multiple_of: multipleOf,
+      resize_mode: resizeMode,
+      upscale_method: upscaleMethod,
+    },
+  };
+}
+
+function directStableWorkflowImageMedia(graph, connection) {
+  const conveyor = imageConveyorWorkflowMedia(graph, connection);
+  if (conveyor?.importable) return conveyor;
+  const directLoadImage = directLoadImageWorkflowMedia(connection);
+  if (directLoadImage?.importable) return directLoadImage;
+  return conveyor || directLoadImage || null;
+}
+
+function scaleImageToTotalPixelsXWorkflowMedia(graph, connection) {
+  const node = connection?.source;
+  if (nodeClassId(node) !== SCALE_IMAGE_TOTAL_PIXELS_X_NODE_CLASS) return null;
+  if (Number(connection?.link?.origin_slot) !== 0) {
+    return {
+      importable: false,
+      reason: "unsupported_transform_output",
+      source_kind: "scale_image_to_total_pixels_x",
+      source_label: "Scale Image to Total Pixels Adv",
+    };
+  }
+
+  const planState = scaleImageToTotalPixelsXPlan(node);
+  if (!planState?.supported) {
+    return {
+      importable: false,
+      reason: planState?.reason || "unsupported_transform_configuration",
+      source_kind: "scale_image_to_total_pixels_x",
+      source_label: "Scale Image to Total Pixels Adv",
+    };
+  }
+
+  const imageInput = (node?.inputs || []).find((input) => input?.name === "image");
+  const upstream = imageInput?.link == null
+    ? null
+    : resolveSourceConnection(graph, imageInput.link, imageInput.type ?? "IMAGE");
+  if (!upstream) {
+    return {
+      importable: false,
+      reason: "missing_transform_source",
+      source_kind: "scale_image_to_total_pixels_x",
+      source_label: "Scale Image to Total Pixels Adv",
+    };
+  }
+  const source = directStableWorkflowImageMedia(graph, { input: imageInput, ...upstream });
+  if (!source?.importable || !source.file || !source.source_identity) {
+    return {
+      importable: false,
+      reason: "unsupported_transform_source",
+      source_kind: "scale_image_to_total_pixels_x",
+      source_label: "Scale Image to Total Pixels Adv",
+    };
+  }
+
+  const materializationPlan = planState.plan;
+  const sourceIdentity = `workflow-materialized-v1:${opaqueStateFingerprint(JSON.stringify([
+    source.source_identity,
+    materializationPlan,
+  ]))}`;
+  return {
+    ...source,
+    importable: true,
+    source_kind: "scale_image_to_total_pixels_x",
+    source_label: `${source.source_label} → Scale Image to Total Pixels Adv`,
+    source_identity: sourceIdentity,
+    materialization_plan: materializationPlan,
+  };
+}
+
+function workflowImageMediaDescriptor(graph, connection) {
+  const materialized = scaleImageToTotalPixelsXWorkflowMedia(graph, connection);
+  if (materialized) return materialized;
+  const conveyor = imageConveyorWorkflowMedia(graph, connection);
+  if (conveyor) return conveyor;
+  const directLoadImage = directLoadImageWorkflowMedia(connection);
+  if (directLoadImage) return directLoadImage;
+  return {
+    importable: false,
+    reason: "unsupported_runtime_source",
+    source_kind: String(nodeClassId(connection?.source) || "workflow"),
+    source_label: String(nodeClassId(connection?.source) || "Workflow image"),
+  };
+}
+
+function workflowSourceIdentityDescriptor(graph, connection) {
+  const materialized = scaleImageToTotalPixelsXWorkflowMedia(graph, connection);
+  if (materialized?.source_identity) return { source_identity: materialized.source_identity };
+  const conveyor = imageConveyorSourceIdentityDescriptor(graph, connection);
+  if (conveyor.source_identity) return conveyor;
+  const directLoadImage = directLoadImageWorkflowMedia(connection);
+  return directLoadImage?.source_identity ? { source_identity: directLoadImage.source_identity } : {};
+}
+
+function slotTypesCompatible(inputType, outputType) {
+  const liteGraph = globalThis.LiteGraph;
+  if (typeof liteGraph?.isValidConnection === "function") {
+    return Boolean(liteGraph.isValidConnection(inputType, outputType));
+  }
+  return inputType === outputType || inputType === "*" || outputType === "*" || inputType === "" || outputType === "";
+}
+
+function bypassInputIndex(node, outputSlot, targetType) {
+  const inputs = node?.inputs || [];
+  const outputType = node?.outputs?.[outputSlot]?.type ?? targetType;
+  if (targetType === "*" || targetType === "") return inputs.length > outputSlot ? outputSlot : (inputs.length ? 0 : -1);
+
+  const opposite = inputs[outputSlot];
+  if (
+    opposite
+    && slotTypesCompatible(opposite.type, outputType)
+    && slotTypesCompatible(opposite.type, targetType)
+  ) {
+    return outputSlot;
+  }
+
+  const exact = inputs.findIndex((candidate) => candidate?.type === targetType);
+  if (exact !== -1) return exact;
+  return inputs.findIndex(
+    (candidate) => slotTypesCompatible(candidate?.type, outputType) && slotTypesCompatible(candidate?.type, targetType),
+  );
+}
+
+function resolveSourceConnection(graph, linkId, targetType, visited = new Set()) {
+  if (linkId == null || visited.has(linkId)) return null;
+  visited.add(linkId);
+  const link = graphLink(graph, linkId);
+  if (!link) return null;
+  const source = graphNode(graph, link.origin_id);
+  if (!source) return null;
+
+  const mode = Number(source.mode ?? 0);
+  if (mode === NODE_MODE_NEVER) return null;
+  if (mode === NODE_MODE_BYPASS) {
+    const inputIndex = bypassInputIndex(source, Number(link.origin_slot), targetType);
+    if (inputIndex < 0) return null;
+    const bypassInput = source.inputs?.[inputIndex];
+    if (!bypassInput || bypassInput.link == null) return null;
+    return resolveSourceConnection(graph, bypassInput.link, targetType, visited);
+  }
+
+  const output = source.outputs?.[link.origin_slot] || null;
+  return { link, source, output };
+}
+
+function sourceForInput(graph, node, inputName) {
+  const input = (node?.inputs || []).find((candidate) => candidate?.name === inputName);
+  if (!input || input.link == null) return null;
+  const resolved = resolveSourceConnection(graph, input.link, input.type);
+  return resolved ? { input, ...resolved } : null;
+}
+
+function sourceDescriptor(connection) {
+  return {
+    source_node_id: connection.source.id,
+    source_node_class: nodeClassId(connection.source),
+    source_output_name: String(connection.output?.name ?? connection.link.origin_slot),
+    source_slot: Number(connection.link.origin_slot),
+  };
+}
+
+export function discoverContinuumReferenceInventory(app, sampler) {
+  if (!isCompatibleContinuumSampler(sampler)) throw new Error("Select a supported H3 Continuum sampler (V3.4–V3.7).");
+  const graph = app?.graph;
+  const items = [];
+
+  const referenceConnections = CONTINUUM_REFERENCE_INPUTS
+    .map((inputName) => ({ inputName, connection: sourceForInput(graph, sampler, inputName) }))
+    .filter((item) => item.connection && connectionIsEffectivelyActive(graph, item.connection));
+
+  referenceConnections.forEach(({ inputName, connection }, offset) => {
+    items.push({
+      tag: `<Picture ${offset + 1}>`,
+      kind: "image",
+      source: "workflow",
+      visible_to_model: false,
+      role: "reference_image",
+      input_name: inputName,
+      ...sourceDescriptor(connection),
+      ...workflowSourceIdentityDescriptor(graph, connection),
+    });
+  });
+
+  const roleConnections = new Map(
+    [...CONDITIONING_ROLES].map(([inputName, role]) => {
+      const connection = sourceForInput(graph, sampler, inputName);
+      return [
+        inputName,
+        { role, connection: connection && connectionIsEffectivelyActive(graph, connection) ? connection : null },
+      ];
+    }),
+  );
+  const hasReferenceImages = referenceConnections.length > 0;
+  let keyframePictureIndex = 0;
+
+  for (const [inputName, { role, connection }] of roleConnections) {
+    if (!connection) continue;
+    let tag = null;
+    if (!hasReferenceImages && (role.role === "first_frame" || role.role === "last_frame")) {
+      keyframePictureIndex += 1;
+      tag = `<Picture ${keyframePictureIndex}>`;
+    } else if (role.role === "video_reference") {
+      tag = "<Video 1>";
+    } else if (role.role === "reference_audio") {
+      tag = "<Audio 1>";
+    }
+    items.push({
+      ...(tag ? { tag } : {}),
+      kind: role.kind,
+      source: "workflow",
+      visible_to_model: false,
+      role: role.role,
+      input_name: inputName,
+      ...sourceDescriptor(connection),
+      ...workflowSourceIdentityDescriptor(graph, connection),
+    });
+  }
+
+  return { schema_version: 1, items };
+}
+
+export function continuumReferenceBindingKey(item = {}) {
+  return JSON.stringify([
+    item.role == null ? null : String(item.role),
+    item.input_name == null ? null : String(item.input_name),
+    item.source_node_id == null ? null : String(item.source_node_id),
+    item.source_node_class == null ? null : String(item.source_node_class),
+    item.source_output_name == null ? null : String(item.source_output_name),
+    Number.isInteger(item.source_slot) ? item.source_slot : null,
+  ]);
+}
+
+function workflowImageRoleLabel(item) {
+  if (item?.tag) return String(item.tag);
+  if (item?.role === "first_frame") return "First Frame";
+  if (item?.role === "last_frame") return "Last Frame";
+  return "Workflow image";
+}
+
+export function discoverContinuumWorkflowImageMedia(app, sampler) {
+  const inventory = discoverContinuumReferenceInventory(app, sampler);
+  const graph = app?.graph;
+  const candidates = inventory.items
+    .filter((item) => item?.kind === "image" && ["reference_image", "first_frame", "last_frame"].includes(item?.role))
+    .map((item) => {
+      const connection = sourceForInput(graph, sampler, item.input_name);
+      const media = connection
+        ? workflowImageMediaDescriptor(graph, connection)
+        : { importable: false, reason: "missing_connection", source_kind: "workflow", source_label: "Workflow image" };
+      return {
+        key: continuumReferenceBindingKey(item),
+        label: workflowImageRoleLabel(item),
+        role: item.role,
+        input_name: item.input_name,
+        tag: item.tag ?? null,
+        source_node_id: item.source_node_id,
+        source_node_class: item.source_node_class,
+        source_output_name: item.source_output_name,
+        source_slot: item.source_slot,
+        source_identity: item.source_identity ?? media.source_identity ?? null,
+        ...media,
+      };
+    });
+  return { inventory, candidates };
+}
+
+function bindingValue(bindings, key) {
+  if (bindings instanceof Map) return bindings.get(key) ?? null;
+  if (bindings && typeof bindings === "object") return bindings[key] ?? null;
+  return null;
+}
+
+export function bindContinuumReferenceMedia(inventory, bindings, assets = []) {
+  const assetIds = new Set(
+    (Array.isArray(assets) ? assets : [])
+      .map((asset) => String(asset?.id ?? ""))
+      .filter(Boolean),
+  );
+  const items = (Array.isArray(inventory?.items) ? inventory.items : []).map((item) => {
+    const binding = bindingValue(bindings, continuumReferenceBindingKey(item));
+    const assetId = String(binding?.asset_id ?? "");
+    const sourceIdentity = item?.source_identity == null ? null : String(item.source_identity);
+    const bindingIdentity = binding?.source_identity == null ? null : String(binding.source_identity);
+    const identityMatches = sourceIdentity == null
+      ? bindingIdentity == null
+      : sourceIdentity === bindingIdentity;
+    if (!assetId || !assetIds.has(assetId) || !identityMatches) {
+      const result = { ...item, visible_to_model: false };
+      delete result.model_asset_id;
+      return result;
+    }
+    return {
+      ...item,
+      visible_to_model: true,
+      model_asset_id: assetId,
+    };
+  });
+  return {
+    schema_version: Number(inventory?.schema_version ?? 1),
+    items,
+  };
+}
+
+function workflowInventoryIdentityItem(item = {}) {
+  const identity = inventoryIdentityItem(item);
+  delete identity.visible_to_model;
+  delete identity.model_asset_id;
+  return identity;
+}
+
+export function sameContinuumWorkflowSourceInventory(savedInventory, activeInventory) {
+  const saved = {
+    schema_version: Number(savedInventory?.schema_version ?? 1),
+    items: (Array.isArray(savedInventory?.items) ? savedInventory.items : []).map(workflowInventoryIdentityItem),
+  };
+  const active = {
+    schema_version: Number(activeInventory?.schema_version ?? 1),
+    items: (Array.isArray(activeInventory?.items) ? activeInventory.items : []).map(workflowInventoryIdentityItem),
+  };
+  if (saved.schema_version !== active.schema_version || saved.items.length !== active.items.length) return false;
+  return saved.items.every((savedValue, index) => {
+    const activeValue = active.items[index];
+    const savedSourceIdentity = savedValue.source_identity;
+    const activeSourceIdentity = activeValue.source_identity;
+    const savedItem = { ...savedValue, source_identity: null };
+    const activeItem = { ...activeValue, source_identity: null };
+    if (JSON.stringify(savedItem) !== JSON.stringify(activeItem)) return false;
+    return savedSourceIdentity == null || savedSourceIdentity === activeSourceIdentity;
+  });
+}
+
+
+export function validateContinuumModeTopology(mode, inventory) {
+  const items = Array.isArray(inventory?.items) ? inventory.items : [];
+  const actual = {
+    first_frame: items.some((item) => item?.role === "first_frame"),
+    last_frame: items.some((item) => item?.role === "last_frame"),
+    reference_images: items.filter((item) => item?.role === "reference_image").length,
+  };
+  if (mode === "Reference") {
+    return { valid: true, mode, required: null, actual };
+  }
+  const expected = {
+    T2VA: [false, false],
+    I2VA: [true, false],
+    FL2VA: [true, true],
+    L2VA: [false, true],
+  };
+  const requiredPair = expected[mode];
+  if (!requiredPair) {
+    return { valid: false, mode, reason: "unsupported_mode", actual };
+  }
+  const required = {
+    first_frame: requiredPair[0],
+    last_frame: requiredPair[1],
+    reference_images: mode === "T2VA" ? 0 : null,
+  };
+  const keyframesMatch = (
+    actual.first_frame === required.first_frame
+    && actual.last_frame === required.last_frame
+  );
+  const referencesMatch = mode !== "T2VA" || actual.reference_images === 0;
+  const valid = keyframesMatch && referencesMatch;
+  const reason = !referencesMatch
+    ? "reference_images_require_reference_mode"
+    : !keyframesMatch
+      ? "temporal_keyframe_mismatch"
+      : null;
+  return { valid, mode, required, actual, reason };
+}
+
+
+function publicReferenceTags(text) {
+  const found = new Set();
+  const pattern = /<\s*(Picture|Video|Audio)\s+(\d+)\s*>/gi;
+  for (const match of String(text ?? "").matchAll(pattern)) {
+    const number = Number(match[2]);
+    if (Number.isInteger(number) && number > 0) {
+      const kind = match[1][0].toUpperCase() + match[1].slice(1).toLowerCase();
+      found.add(`<${kind} ${number}>`);
+    }
+  }
+  return found;
+}
+
+function sortedTags(values) {
+  return [...values].sort((a, b) => a.localeCompare(b, "en", { numeric: true }));
+}
+
+export function validateContinuumReferenceScope(inventory, preamble, prompts) {
+  const items = Array.isArray(inventory?.items) ? inventory.items : [];
+  const bodies = Array.isArray(prompts) ? prompts : [];
+  const expected = new Set(items.filter((item) => item?.tag).map((item) => String(item.tag)));
+  const persistent = new Set(
+    items
+      .filter((item) => item?.tag && (
+        bodies.length === 1
+        || item.role === "reference_image"
+        || item.role === "video_reference"
+        || item.role === "reference_audio"
+      ))
+      .map((item) => String(item.tag)),
+  );
+  const scopes = bodies.map((_prompt, index) => {
+    const allowed = new Set();
+    items.forEach((item) => {
+      if (!item?.tag) return;
+      if (item.role === "reference_image" || item.role === "video_reference" || item.role === "reference_audio") {
+        allowed.add(String(item.tag));
+      } else if (item.role === "first_frame" && index === 0) {
+        allowed.add(String(item.tag));
+      } else if (item.role === "last_frame" && index === bodies.length - 1) {
+        allowed.add(String(item.tag));
+      }
+    });
+    return allowed;
+  });
+
+  const violations = [];
+  const globalRefs = publicReferenceTags(preamble);
+  const undeclaredGlobal = new Set([...globalRefs].filter((tag) => !expected.has(tag)));
+  if (undeclaredGlobal.size) {
+    violations.push({
+      kind: "undeclared",
+      scope: "global",
+      tags: sortedTags(undeclaredGlobal),
+      allowed: sortedTags(expected),
+    });
+  }
+  const scopedGlobal = new Set(
+    [...globalRefs].filter((tag) => expected.has(tag) && !persistent.has(tag)),
+  );
+  if (scopedGlobal.size) {
+    violations.push({
+      kind: "scope",
+      scope: "global",
+      tags: sortedTags(scopedGlobal),
+      allowed: sortedTags(persistent),
+    });
+  }
+
+  bodies.forEach((prompt, index) => {
+    const refs = publicReferenceTags(prompt);
+    const undeclared = new Set([...refs].filter((tag) => !expected.has(tag)));
+    if (undeclared.size) {
+      violations.push({
+        kind: "undeclared",
+        scope: "chunk",
+        chunk_index: index + 1,
+        tags: sortedTags(undeclared),
+        allowed: sortedTags(expected),
+      });
+    }
+    const scoped = new Set(
+      [...refs].filter((tag) => expected.has(tag) && !scopes[index].has(tag)),
+    );
+    if (scoped.size) {
+      violations.push({
+        kind: "scope",
+        scope: "chunk",
+        chunk_index: index + 1,
+        tags: sortedTags(scoped),
+        allowed: sortedTags(scopes[index]),
+      });
+    }
+  });
+
+  return {
+    valid: violations.length === 0,
+    violations,
+    expected: sortedTags(expected),
+    persistent: sortedTags(persistent),
+    chunk_scopes: scopes.map(sortedTags),
+  };
+}
+
+
+function editableMultilineWidget(node) {
+  if (!EDITABLE_MULTILINE_NODE_IDS.has(nodeClassId(node))) return null;
+  const valueWidget = widget(node, "value") || (node?.widgets || []).find((candidate) => typeof candidate?.value === "string");
+  const stringOutput = (node?.outputs || []).some((output) => output?.type === "STRING");
+  return stringOutput && valueWidget ? valueWidget : null;
+}
+
+export function connectedSequenceTextSource(graph, sampler) {
+  const input = (sampler?.inputs || []).find((candidate) => candidate?.name === "sequence_prompt");
+  if (!input || input.link == null) return { status: "unconnected" };
+  let link = graphLink(graph, input.link);
+  const visited = new Set();
+  while (link) {
+    const source = graphNode(graph, link.origin_id);
+    if (!source || visited.has(source.id) || Number(source.mode) === NODE_MODE_NEVER) break;
+    visited.add(source.id);
+    if (Number(source.mode) === NODE_MODE_BYPASS) {
+      const inputIndex = bypassInputIndex(source, Number(link.origin_slot), "STRING");
+      if (inputIndex < 0) break;
+      link = graphLink(graph, source.inputs?.[inputIndex]?.link);
+      continue;
+    }
+    const sourceWidget = editableMultilineWidget(source);
+    if (sourceWidget) return { status: "connected", node: source, widget: sourceWidget };
+    const stringInputs = (source.inputs || []).filter((candidate) => candidate?.type === "STRING" && candidate.link != null);
+    const stringOutputs = (source.outputs || []).filter((candidate) => candidate?.type === "STRING");
+    if (stringInputs.length !== 1 || stringOutputs.length !== 1) break;
+    link = graphLink(graph, stringInputs[0].link);
+  }
+  return { status: "incompatible_source" };
+}
+
+function setWidgetValue(app, node, target, value) {
+  const previous = target.value;
+  target.value = value;
+  if (typeof target.callback === "function") target.callback(value, app?.canvas, node);
+  if (typeof node?.onWidgetChanged === "function") node.onWidgetChanged(target.name, value, previous, target);
+  node?.graph?.setDirtyCanvas?.(true, true);
+  app?.graph?.setDirtyCanvas?.(true, true);
+  app?.canvas?.setDirty?.(true, true);
+  app?.graph?.change?.();
+}
+
+function applyWidgetMutations(app, mutations) {
+  const applied = [];
+  try {
+    for (const mutation of mutations) {
+      const previous = mutation.target.value;
+      applied.push({ ...mutation, previous });
+      setWidgetValue(app, mutation.node, mutation.target, mutation.value);
+    }
+    return null;
+  } catch (error) {
+    for (const mutation of applied.reverse()) {
+      try {
+        setWidgetValue(app, mutation.node, mutation.target, mutation.previous);
+      } catch {
+        mutation.target.value = mutation.previous;
+      }
+    }
+    return error;
+  }
+}
+
+
+export function continuumSamplerSettings(sampler) {
+  return {
+    prompt_mode: String(widget(sampler, "prompt_mode")?.value ?? ""),
+    chunks: Number(widget(sampler, "chunks")?.value),
+    chunk_seconds: Number(widget(sampler, "chunk_seconds")?.value),
+  };
+}
+
+export function applySequenceToContinuum(app, sampler, sequenceState, { syncSettings = false, mode = null } = {}) {
+  if (!isCompatibleContinuumSampler(sampler)) return { status: "incompatible_sampler" };
+  const settings = normalizeContinuumSettings(sequenceState?.settings || {});
+  const preamble = typeof sequenceState?.preamble === "string"
+    ? sequenceState.preamble
+    : typeof sequenceState?.plan?.global?.sequence_preamble === "string"
+      ? sequenceState.plan.global.sequence_preamble
+      : "";
+  const prompt = serializeContinuumPrompts(sequenceState?.prompts || [], {
+    preamble,
+    chunkSeconds: settings.chunk_seconds,
+  });
+  const parsed = parseContinuumTimeline(prompt, {
+    expectedChunks: settings.chunks,
+    chunkSeconds: settings.chunk_seconds,
+  });
+  const inventory = discoverContinuumReferenceInventory(app, sampler);
+  if (
+    sequenceState?.downstream_reference_inventory
+    && !sameContinuumWorkflowSourceInventory(sequenceState.downstream_reference_inventory, inventory)
+  ) {
+    return {
+      status: "source_inventory_mismatch",
+      saved_inventory: sequenceState.downstream_reference_inventory,
+      inventory,
+      prompt,
+      sampler,
+    };
+  }
+  if (mode) {
+    const modeTopology = validateContinuumModeTopology(mode, inventory);
+    if (!modeTopology.valid) {
+      return {
+        status: "mode_topology_mismatch",
+        mode_topology: modeTopology,
+        inventory,
+        prompt,
+        sampler,
+      };
+    }
+  }
+  const referenceScope = validateContinuumReferenceScope(
+    inventory,
+    parsed.preamble,
+    parsed.prompts,
+  );
+  if (!referenceScope.valid) {
+    return {
+      status: "reference_mismatch",
+      violations: referenceScope.violations,
+      inventory,
+      prompt,
+      sampler,
+    };
+  }
+
+  const source = connectedSequenceTextSource(app?.graph, sampler);
+  if (source.status !== "connected") return { ...source, sampler, prompt };
+
+  const current = continuumSamplerSettings(sampler);
+  const mismatches = [];
+  if (current.prompt_mode !== CONTINUUM_PROMPT_MODE) {
+    mismatches.push({ field: "prompt_mode", writer: CONTINUUM_PROMPT_MODE, sampler: current.prompt_mode || "(unset)" });
+  }
+  if (current.chunks !== settings.chunks) mismatches.push({ field: "chunks", writer: settings.chunks, sampler: current.chunks });
+  if (current.chunk_seconds !== settings.chunk_seconds) {
+    mismatches.push({ field: "chunk_seconds", writer: settings.chunk_seconds, sampler: current.chunk_seconds });
+  }
+  if (mismatches.length && !syncSettings) return { status: "mismatch", mismatches, sampler };
+
+  const mutations = [];
+  if (syncSettings) {
+    if (current.prompt_mode !== CONTINUUM_PROMPT_MODE) {
+      mutations.push({
+        node: sampler,
+        target: widget(sampler, "prompt_mode"),
+        value: CONTINUUM_PROMPT_MODE,
+      });
+    }
+    if (current.chunks !== settings.chunks) {
+      mutations.push({
+        node: sampler,
+        target: widget(sampler, "chunks"),
+        value: settings.chunks,
+      });
+    }
+    if (current.chunk_seconds !== settings.chunk_seconds) {
+      mutations.push({
+        node: sampler,
+        target: widget(sampler, "chunk_seconds"),
+        value: settings.chunk_seconds,
+      });
+    }
+  }
+  mutations.push({ node: source.node, target: source.widget, value: prompt });
+
+  const applyError = applyWidgetMutations(app, mutations);
+  if (applyError) {
+    return {
+      status: "apply_failed",
+      sampler,
+      prompt,
+      message: applyError instanceof Error ? applyError.message : String(applyError),
+    };
+  }
+  return {
+    status: "applied",
+    sampler,
+    source: source.node,
+    prompt,
+    settings,
+    prompt_mode: CONTINUUM_PROMPT_MODE,
+  };
+}
+
+export function continuumSamplerLabel(node) {
+  const title = String(node?.title || "H3 Continuum Sampler");
+  return node?.id == null ? title : `${title} · node ${node.id}`;
+}

--- a/web/main.js
+++ b/web/main.js
@@ -1,6 +1,24 @@
 import { app } from "/scripts/app.js";
-import { cancel, clearMedia, diagnoseGGUFRuntime, disconnectApiProvider, freeComfyVram, generate, getApiProviderModels, getApiProviderPresets, getGuides, getModels, getOllamaStatus, getStatus, getSystemPrompt, probeApiProvider, probeExternalServer, refine, removeMedia, reorderMedia, resampleMedia, unloadModel, uploadMedia } from "./api/h3studio.js";
+import { cancel, clearMedia, diagnoseGGUFRuntime, disconnectApiProvider, fetchComfyImageFile, freeComfyVram, generate, getApiProviderModels, getApiProviderPresets, getGuides, getModels, getOllamaStatus, getStatus, getSystemPrompt, materializeWorkflowImage, probeApiProvider, probeExternalServer, refine, removeMedia, reorderMedia, resampleMedia, unloadModel, uploadMedia } from "./api/h3studio.js";
 import { availableReferenceTags, comfyVramIsAlreadyEmpty, createSessionId, fileCountFromDataTransfer, insertReferenceAtCaret, isChoiceMenuInteraction, isGuideMenuInteraction, isRuntimeMenuInteraction, moveOntoTarget, replacementTargetForFileDrop, replaceEventListener, vramReleaseReachedTarget } from "./compat.js";
+import {
+  applySequenceToContinuum,
+  chooseContinuumSampler,
+  CONTINUUM_MAX_CHUNKS,
+  CONTINUUM_MAX_SECONDS,
+  CONTINUUM_MIN_CHUNKS,
+  CONTINUUM_MIN_SECONDS,
+  bindContinuumReferenceMedia,
+  continuumDraftOutput,
+  continuumSamplerLabel,
+  discoverContinuumReferenceInventory,
+  discoverContinuumWorkflowImageMedia,
+  parseContinuumTimeline,
+  sequenceStateFromResult,
+  sameContinuumReferenceInventory,
+  updateContinuumDraftFromEditor,
+  validateContinuumModeTopology,
+} from "./continuum.js";
 import { generateModelSummaryMarkup, settingsMarkup } from "./settings.js";
 import {
   buildGeneratePayload,
@@ -373,6 +391,217 @@ function icon(name, size = 16) {
   return `<svg viewBox="0 0 24 24" width="${size}" height="${size}" aria-hidden="true">${paths[name] || paths.info}</svg>`;
 }
 
+function workflowReferenceState() {
+  if (!studio || studio.mode !== "Reference" || studio.generationTarget !== "continuum") {
+    return { status: "hidden", candidates: [], inventory: null };
+  }
+  const choice = chooseContinuumSampler(app);
+  if (choice.status !== "selected") return { status: choice.status, candidates: [], inventory: null };
+  try {
+    const discovered = discoverContinuumWorkflowImageMedia(app, choice.sampler);
+    return { status: "ready", sampler: choice.sampler, ...discovered };
+  } catch (error) {
+    return { status: "error", candidates: [], inventory: null, error };
+  }
+}
+
+function workflowBindingStatus(candidate) {
+  const binding = studio.workflowReferenceBindings?.[candidate.key] || null;
+  const asset = binding
+    ? studio.assets.find((item) => String(item.id) === String(binding.asset_id)) || null
+    : null;
+  if (!binding || !asset) return { binding, asset, state: "missing" };
+  const currentIdentity = candidate.source_identity == null ? null : String(candidate.source_identity);
+  const boundIdentity = binding.source_identity == null ? null : String(binding.source_identity);
+  return {
+    binding,
+    asset,
+    state: currentIdentity === boundIdentity ? "current" : "stale",
+  };
+}
+
+function workflowReferencePreviewUrl(candidate) {
+  if (!candidate?.file) return "";
+  const query = new URLSearchParams({
+    filename: candidate.file.filename,
+    subfolder: candidate.file.subfolder || "",
+    type: candidate.file.type || "input",
+  });
+  return `/view?${query.toString()}`;
+}
+
+function workflowReferenceReason(candidate) {
+  return {
+    dynamic_queue_group: "Dynamic queue-group image; the file is chosen when the workflow is queued.",
+    queue_driven_output: "Queue-driven image; there is no stable file to attach before execution.",
+    processed_image_chain: "This slot passes through an unsupported image-processing chain; Writer cannot copy the exact runtime pixels before execution.",
+    dynamic_transform_parameters: "Scale Image to Total Pixels Adv has connected width/height overrides, so its final pixels are dynamic.",
+    unsupported_transform_configuration: "Scale Image to Total Pixels Adv has a configuration Writer cannot reproduce safely.",
+    unsupported_transform_method: "Only Lanczos Scale Image to Total Pixels Adv chains are currently materialized exactly.",
+    unsupported_transform_output: "Writer only materializes the image output of Scale Image to Total Pixels Adv.",
+    missing_transform_source: "Scale Image to Total Pixels Adv has no resolvable static image source.",
+    unsupported_transform_source: "Scale Image to Total Pixels Adv is fed by a source that Writer cannot materialize exactly.",
+    unreadable_reference_file: "The active Reference Shelf slot has no readable ComfyUI file descriptor.",
+    unsupported_runtime_source: "This active workflow source cannot be materialized into Writer media safely.",
+    missing_connection: "The active workflow image connection could not be resolved.",
+  }[candidate?.reason] || "This workflow image cannot be attached automatically.";
+}
+
+function renderWorkflowReferencePanel() {
+  const state = workflowReferenceState();
+  if (state.status === "hidden") return "";
+  const header = (detail, action = "") => `
+    <section class="h3ps-workflow-references">
+      <header>
+        <span><strong>Active workflow images</strong><small>${detail}</small></span>
+        <span class="h3ps-workflow-reference-actions">${action}<button type="button" class="h3ps-quiet-button" data-workflow-ref-refresh>Refresh</button></span>
+      </header>`;
+
+  if (state.status === "missing") {
+    return `${header("Add H3 Continuum Sampler V3.4–V3.7 to expose its active image conditioning.")}<p class="h3ps-workflow-reference-empty">No compatible Continuum sampler is present.</p></section>`;
+  }
+  if (state.status === "multiple") {
+    return `${header("Select exactly one H3 Continuum Sampler V3.4–V3.7 on the canvas.")}<p class="h3ps-workflow-reference-empty">Multiple compatible samplers are present.</p></section>`;
+  }
+  if (state.status === "error") {
+    return `${header("Writer could not resolve the active workflow image state.")}<p class="h3ps-workflow-reference-empty">${escapeHtml(state.error?.message || "Workflow reference discovery failed.")}</p></section>`;
+  }
+
+  const candidates = state.candidates;
+  const actionable = candidates.filter((candidate) => {
+    if (!candidate.importable) return false;
+    return workflowBindingStatus(candidate).state !== "current";
+  });
+  const addAll = candidates.length
+    ? `<button type="button" class="h3ps-secondary-button h3ps-workflow-add-all" data-workflow-ref-add-all ${!actionable.length || studio.workflowReferenceImportBusy ? "disabled" : ""}>${actionable.length ? `Add active workflow refs (${actionable.length})` : "Active refs added"}</button>`
+    : "";
+  const detail = candidates.length
+    ? `${candidates.length} active image conditioning input${candidates.length === 1 ? "" : "s"} on the selected sampler. Add stable images here so the prompt model can actually inspect them.`
+    : "The selected sampler currently has no active image conditioning inputs.";
+
+  const rows = candidates.map((candidate, index) => {
+    const binding = workflowBindingStatus(candidate);
+    // Once a stable workflow source has been imported, show the exact Writer
+    // asset the prompt model will inspect. For a materialized transform this is
+    // the post-transform image, not the upstream source thumbnail.
+    const preview = binding.state === "current" && binding.asset?.preview_url
+      ? binding.asset.preview_url
+      : candidate.importable ? workflowReferencePreviewUrl(candidate) : "";
+    const status = binding.state === "current"
+      ? "Writer can see"
+      : binding.state === "stale"
+        ? "Update needed"
+        : candidate.importable
+          ? "Workflow only"
+          : candidate.reason === "dynamic_queue_group" || candidate.reason === "queue_driven_output"
+            ? "Dynamic at execution"
+            : candidate.reason === "unsupported_transform_method"
+              ? "Unsupported resize method"
+              : candidate.reason === "dynamic_transform_parameters"
+                ? "Dynamic resize inputs"
+                : "Exact pixels unavailable";
+    const action = candidate.importable
+      ? `<button type="button" data-workflow-ref-add="${index}" ${studio.workflowReferenceImportBusy || binding.state === "current" ? "disabled" : ""}>${binding.state === "current" ? "Added" : binding.state === "stale" ? "Update" : "Add"}</button>`
+      : `<button type="button" disabled title="${escapeHtml(workflowReferenceReason(candidate))}">Unavailable</button>`;
+    const detailText = candidate.source_label
+      ? `${candidate.input_name} · ${candidate.source_label}`
+      : candidate.input_name;
+    return `
+      <div class="h3ps-workflow-reference-row ${binding.state === "current" ? "is-bound" : binding.state === "stale" ? "is-stale" : ""}">
+        <span class="h3ps-workflow-reference-thumb">${preview ? `<img src="${escapeHtml(preview)}" alt="">` : icon("image", 16)}</span>
+        <span class="h3ps-workflow-reference-copy"><strong>${escapeHtml(candidate.label)}</strong><small>${escapeHtml(detailText)}</small></span>
+        <em title="${candidate.importable ? "" : escapeHtml(workflowReferenceReason(candidate))}">${status}</em>
+        ${action}
+      </div>`;
+  }).join("");
+
+  return `${header(detail, addAll)}<div class="h3ps-workflow-reference-list">${rows || '<p class="h3ps-workflow-reference-empty">No active workflow image slots.</p>'}</div></section>`;
+}
+
+function forgetWorkflowReferenceAsset(assetId) {
+  for (const [key, binding] of Object.entries(studio.workflowReferenceBindings || {})) {
+    if (String(binding?.asset_id ?? "") === String(assetId ?? "")) delete studio.workflowReferenceBindings[key];
+  }
+}
+
+async function importWorkflowReferenceCandidates(candidates) {
+  if (studio.workflowReferenceImportBusy || !Array.isArray(candidates) || !candidates.length) return;
+  const actionable = candidates.filter((candidate) => {
+    if (!candidate?.importable || !candidate.file) return false;
+    return workflowBindingStatus(candidate).state !== "current";
+  });
+  if (!actionable.length) {
+    showToast("Workflow references are current", "All importable active workflow images are already visible to the prompt model.");
+    return;
+  }
+
+  const referenceImages = studio.assets.filter((asset) => asset.mode === "Reference" && asset.type === "image").length;
+  const additions = actionable.filter((candidate) => !workflowBindingStatus(candidate).asset).length;
+  if (referenceImages + additions > 9) {
+    showToast(
+      "Reference image limit reached",
+      `Adding these workflow references would require ${referenceImages + additions} images, but Reference mode accepts at most 9. Remove unused analysis images first.`,
+    );
+    return;
+  }
+
+  studio.workflowReferenceImportBusy = true;
+  renderMedia(studio.mode);
+  let imported = 0;
+  try {
+    for (const candidate of actionable) {
+      const before = workflowBindingStatus(candidate);
+      const file = await fetchComfyImageFile(candidate.file, candidate.file.filename);
+      const replaceAssetId = before.asset?.id || null;
+      const result = candidate.materialization_plan
+        ? await materializeWorkflowImage(
+          studio.sessionId,
+          "Reference",
+          file,
+          candidate.materialization_plan,
+          replaceAssetId,
+        )
+        : await uploadMedia(studio.sessionId, "Reference", [file], replaceAssetId);
+      let assetId = replaceAssetId;
+      if (replaceAssetId) {
+        studio.assets = result.assets;
+      } else {
+        const added = result.assets?.[0];
+        if (!added?.id) throw new Error("Writer did not return the imported workflow image asset.");
+        studio.assets = [...studio.assets, ...result.assets];
+        assetId = added.id;
+      }
+      studio.workflowReferenceBindings[candidate.key] = {
+        asset_id: assetId,
+        source_identity: candidate.source_identity ?? null,
+        label: candidate.label,
+        input_name: candidate.input_name,
+      };
+      imported += 1;
+    }
+    showToast(
+      "Workflow references added",
+      `${imported} active workflow image${imported === 1 ? "" : "s"} ${imported === 1 ? "is" : "are"} now visible to the prompt model and bound to the matching downstream conditioning slot${imported === 1 ? "" : "s"}.`,
+      null,
+      null,
+      { durationMs: 5200 },
+    );
+  } catch (error) {
+    showToast(error.code || "Workflow reference import failed", error.message, error.details);
+  } finally {
+    studio.workflowReferenceImportBusy = false;
+    renderMedia(studio.mode);
+  }
+}
+
+function bindActiveWorkflowReferenceMedia(inventory) {
+  return bindContinuumReferenceMedia(
+    inventory,
+    studio.workflowReferenceBindings,
+    studio.assets,
+  );
+}
+
 function renderAsset(asset, index) {
   const destructiveDisabled = studio.requestBusy ? "disabled" : "";
   const draggable = studio.requestBusy ? "false" : "true";
@@ -425,6 +654,7 @@ function renderMedia(mode) {
     const filter = isReference ? studio.mediaFilter : "all";
     const visibleAssets = filter === "all" ? assets : assets.filter((asset) => asset.type === filter);
     const counts = assets.reduce((result, asset) => ({ ...result, [asset.type]: (result[asset.type] || 0) + 1 }), {});
+    const workflowReferences = isReference ? renderWorkflowReferencePanel() : "";
     const filters = isReference ? `
       <div class="h3ps-media-filters" aria-label="Reference type">
         <button type="button" data-media-filter="all" class="${filter === "all" ? "is-active" : ""}">All <b>${assets.length}/12</b></button>
@@ -435,6 +665,7 @@ function renderMedia(mode) {
     const addLabel = !isReference || filter === "image" ? "Add image" : filter === "video" ? "Add video" : filter === "audio" ? "Add audio" : "Add media";
     const canAdd = isReference || assets.length < data.limit;
     media.innerHTML = `
+      ${workflowReferences}
       ${filters}
       <div class="h3ps-assets ${isReference ? "is-reference" : ""}">${visibleAssets.map((asset) => renderAsset(asset, assets.indexOf(asset))).join("")}
         ${canAdd ? `<button class="${assets.length ? "h3ps-add-asset" : "h3ps-empty-drop"}" type="button" data-add-media ${studio.requestBusy ? "disabled" : ""}>${icon("plus", 18)}<span>${addLabel}</span><small>Drop files here</small></button>` : ""}
@@ -482,6 +713,15 @@ function referenceTagKind(reference) {
 
 function referenceTagsForCurrentDraft() {
   if (!studio || studio.mode !== "Reference") return [];
+  if (studio.generationTarget === "continuum") {
+    const workflow = workflowReferenceState();
+    if (workflow.status === "ready") {
+      return workflow.inventory.items
+        .map((item) => item?.tag)
+        .filter(Boolean)
+        .map(String);
+    }
+  }
   return availableReferenceTags(studio.assets, studio.root.querySelector("[data-output]").value);
 }
 
@@ -540,6 +780,24 @@ function insertSelectedReference(reference) {
 
 function bindMediaActions(mode) {
   const media = studio.root.querySelector("[data-h3ps-media]");
+  studio.root.querySelectorAll("[data-workflow-ref-refresh]").forEach((button) => {
+    button.addEventListener("click", () => renderMedia(mode));
+  });
+  studio.root.querySelectorAll("[data-workflow-ref-add-all]").forEach((button) => {
+    button.addEventListener("click", () => {
+      const current = workflowReferenceState();
+      if (current.status === "ready") void importWorkflowReferenceCandidates(current.candidates);
+    });
+  });
+  studio.root.querySelectorAll("[data-workflow-ref-add]").forEach((button) => {
+    button.addEventListener("click", () => {
+      const current = workflowReferenceState();
+      const candidate = current.status === "ready"
+        ? current.candidates[Number(button.dataset.workflowRefAdd)]
+        : null;
+      if (candidate) void importWorkflowReferenceCandidates([candidate]);
+    });
+  });
   studio.root.querySelectorAll("[data-media-filter]").forEach((button) => {
     button.addEventListener("click", () => {
       studio.mediaFilter = button.dataset.mediaFilter;
@@ -564,8 +822,10 @@ function bindMediaActions(mode) {
     button.addEventListener("click", async (event) => {
       event.stopPropagation();
       try {
-        const result = await removeMedia(studio.sessionId, button.dataset.removeAsset);
+        const removedAssetId = button.dataset.removeAsset;
+        const result = await removeMedia(studio.sessionId, removedAssetId);
         studio.assets = result.assets;
+        forgetWorkflowReferenceAsset(removedAssetId);
         renderMedia(mode);
       } catch (error) {
         showToast(error.code || "Remove failed", error.message, error.details);
@@ -680,6 +940,10 @@ async function uploadFiles(mode, files, replaceAssetId = null) {
     const result = await uploadMedia(studio.sessionId, mode, files, replaceAssetId);
     studio.sessionId = result.session_id;
     studio.assets = replaceAssetId ? result.assets : [...studio.assets, ...result.assets];
+    // A manual Replace changes the Prompt Writer copy independently of its
+    // workflow source. Drop any workflow binding only after replacement
+    // succeeds; the Active workflow images panel will then offer Add again.
+    if (replaceAssetId) forgetWorkflowReferenceAsset(replaceAssetId);
     renderMedia(mode);
     hideToast();
     if (audioWasAdded(previousAssets, studio.assets)) {
@@ -856,10 +1120,32 @@ function defaultModeDraft(mode) {
 }
 
 function currentDraftFields() {
-  return {
+  const output = studio.root.querySelector("[data-output]").value;
+  const existing = studio.modeDrafts[studio.mode] || {};
+  const base = {
     brief: currentBriefTextarea().value,
     lyrics: studio.mode === "Music3" ? studio.root.querySelector("[data-music-lyrics]").value : "",
-    prompt: studio.root.querySelector("[data-output]").value,
+  };
+  if (studio.mode === "Music3") return { ...base, prompt: output };
+  if (studio.generationTarget === "continuum") {
+    const continuum = studio.continuumSequence?.plan
+      ? updateContinuumDraftFromEditor(studio.continuumSequence, output)
+      : studio.continuumSequence;
+    studio.continuumSequence = continuum;
+    return {
+      ...base,
+      prompt: "",
+      single_prompt: existing.single_prompt || existing.prompt || defaultModeDraft(studio.mode).prompt,
+      generation_target: "continuum",
+      continuum,
+    };
+  }
+  return {
+    ...base,
+    prompt: output,
+    single_prompt: output,
+    generation_target: "single",
+    continuum: studio.continuumSequence || existing.continuum || null,
   };
 }
 
@@ -882,6 +1168,7 @@ function clearCurrentPrompts({ notify = true } = {}) {
   const output = studio.root.querySelector("[data-output]");
   currentBriefTextarea().value = draft.brief;
   output.value = draft.prompt;
+  if (studio.mode !== "Music3") studio.continuumSequence = draft.continuum || null;
   studio.lastModelPrompt = null;
   studio.lastModelMeta = null;
   studio.refineRestore = null;
@@ -893,7 +1180,8 @@ function clearCurrentPrompts({ notify = true } = {}) {
   renderPromptHighlights();
   syncModifiedState();
   syncReferenceInsertControl();
-  saveCurrentModeDraft();
+  studio.modeDrafts[studio.mode] = draft;
+  saveModeDrafts(localStorage, studio.modeDrafts);
   if (notify) {
     const detail = studio.mode === "Music3"
       ? "The Music Brief and generated caption were cleared. Lyrics and media were kept."
@@ -908,6 +1196,7 @@ async function clearCurrentMedia({ notify = true } = {}) {
   try {
     const result = await clearMedia(studio.sessionId, studio.mode);
     studio.assets = result.assets;
+    if (studio.mode === "Reference") studio.workflowReferenceBindings = {};
     closeVideoPreview();
     closeImagePreview();
     renderMedia(studio.mode);
@@ -966,9 +1255,19 @@ function restoreModeDraft(mode) {
   const output = studio.root.querySelector("[data-output]");
   currentBriefTextarea().value = draft.brief;
   if (mode === "Music3") studio.root.querySelector("[data-music-lyrics]").value = draft.lyrics || "";
-  output.value = draft.prompt;
-  studio.lastModelPrompt = draft.prompt;
-  studio.lastModelMeta = promptLengthMeta(draft.prompt);
+  const savedTarget = mode === "Music3" ? "single" : draft.generation_target || studio.generationTarget || "single";
+  studio.generationTarget = savedTarget;
+  studio.continuumSequence = mode === "Music3" ? null : draft.continuum || null;
+  if (studio.continuumSequence?.settings) {
+    studio.continuumChunks = studio.continuumSequence.settings.chunks;
+    studio.continuumChunkSeconds = studio.continuumSequence.settings.chunk_seconds;
+  }
+  const prompt = savedTarget === "continuum"
+    ? studio.continuumSequence ? continuumDraftOutput(studio.continuumSequence) : ""
+    : draft.single_prompt || draft.prompt;
+  output.value = prompt;
+  studio.lastModelPrompt = prompt;
+  studio.lastModelMeta = promptLengthMeta(prompt);
   studio.refineRestore = null;
   studio.root.querySelector("[data-refine-restore]").hidden = true;
   studio.lyricsRestore = null;
@@ -976,8 +1275,215 @@ function restoreModeDraft(mode) {
   studio.root.querySelector(".h3ps-editor-meta span:last-child").textContent = promptLengthMeta(output.value);
   updateBriefLayout();
   updateMusicLyricsCount();
+  syncGenerationTarget();
+  syncModeAvailability();
   renderPromptHighlights();
   syncModifiedState();
+}
+
+function syncContinuumChunkSelector() {
+  if (!studio?.root) return;
+  const field = studio.root.querySelector("[data-refine-chunk-field]");
+  const select = studio.root.querySelector("[data-refine-chunk]");
+  const active = studio.mode !== "Music3" && studio.generationTarget === "continuum";
+  field.hidden = !active;
+  if (!active) return;
+  const previous = Number(select.value) || 1;
+  select.innerHTML = Array.from({ length: studio.continuumChunks }, (_, offset) => (
+    `<option value="${offset + 1}">Chunk ${offset + 1}</option>`
+  )).join("");
+  select.value = String(Math.min(previous, studio.continuumChunks));
+}
+
+function syncGenerationTarget() {
+  if (!studio?.root) return;
+  const active = studio.mode !== "Music3" && studio.generationTarget === "continuum";
+  studio.root.querySelectorAll("[data-generation-target]").forEach((button) => {
+    const selected = button.dataset.generationTarget === (active ? "continuum" : "single");
+    button.classList.toggle("is-active", selected);
+    button.setAttribute("aria-pressed", String(selected));
+    button.disabled = studio.requestBusy;
+  });
+  studio.root.querySelector("[data-generation-target-control]").hidden = studio.mode === "Music3";
+  studio.root.querySelector("[data-single-duration-field]").hidden = active;
+  studio.root.querySelector("[data-continuum-settings]").hidden = !active;
+  studio.root.querySelector("[data-continuum-chunks]").value = String(studio.continuumChunks);
+  studio.root.querySelector("[data-continuum-seconds]").value = String(studio.continuumChunkSeconds);
+  studio.root.querySelector("[data-continuum-total]").textContent = `${(studio.continuumChunks * studio.continuumChunkSeconds).toFixed(1).replace(/\.0$/, "")} seconds total`;
+  const badge = studio.root.querySelector("[data-continuum-output-badge]");
+  badge.hidden = !active;
+  badge.textContent = active ? `${studio.continuumChunks} chunks · ${Number(studio.continuumChunkSeconds).toLocaleString()}s each` : "";
+  studio.root.querySelector("[data-output-label]").textContent = studio.mode === "Music3" ? "Generated caption" : active ? "Continuum sequence" : "Generated prompt";
+  studio.root.querySelector("[data-copy-label]").textContent = studio.mode === "Music3" ? "Copy caption" : active ? "Copy sequence" : "Copy prompt";
+  const generateLabel = studio.root.querySelector("[data-generate-label]");
+  if (generateLabel && !studio.requestBusy) generateLabel.textContent = studio.mode === "Music3" ? "Generate caption" : active ? "Generate sequence" : "Generate prompt";
+  studio.root.querySelector("[data-apply-continuum]").hidden = !active;
+  studio.root.querySelector("[data-apply-continuum]").disabled = studio.requestBusy || !studio.continuumSequence?.plan;
+  studio.root.querySelector("[data-refine-title]").textContent = active ? "Refine one chunk" : studio.mode === "Music3" ? "Refine caption" : "Refine prompt";
+  studio.root.querySelector("[data-refine-helper]").textContent = active ? "Only the selected chunk changes" : studio.mode === "Music3" ? "Describe the musical change" : "Describe only what should change";
+  syncContinuumChunkSelector();
+}
+
+function setGenerationTarget(target) {
+  if (studio.mode === "Music3" || !["single", "continuum"].includes(target) || target === studio.generationTarget) return;
+  saveCurrentModeDraft();
+  studio.generationTarget = target;
+  const draft = studio.modeDrafts[studio.mode] || {};
+  const output = studio.root.querySelector("[data-output]");
+  if (target === "continuum") {
+    studio.continuumSequence = draft.continuum || studio.continuumSequence;
+    if (studio.continuumSequence?.settings) {
+      studio.continuumChunks = studio.continuumSequence.settings.chunks;
+      studio.continuumChunkSeconds = studio.continuumSequence.settings.chunk_seconds;
+      output.value = continuumDraftOutput(studio.continuumSequence);
+    } else {
+      output.value = "";
+    }
+  } else {
+    output.value = draft.single_prompt || draft.prompt || defaultModeDraft(studio.mode).prompt;
+  }
+  studio.lastModelPrompt = output.value;
+  studio.lastModelMeta = promptLengthMeta(output.value);
+  studio.root.querySelector(".h3ps-editor-meta span:last-child").textContent = studio.lastModelMeta;
+  syncGenerationTarget();
+  renderMedia(studio.mode);
+  renderPromptHighlights();
+  syncModifiedState();
+  saveCurrentModeDraft();
+  saveUserPreferences(localStorage, studio);
+}
+
+async function applyCurrentSequence(syncSettings = false) {
+  if (!studio.continuumSequence?.plan) {
+    showToast("No Continuum sequence", "Generate a valid H3 Continuum sequence first.");
+    return;
+  }
+  studio.continuumSequence = updateContinuumDraftFromEditor(
+    studio.continuumSequence,
+    studio.root.querySelector("[data-output]").value,
+  );
+  if (studio.continuumSequence.raw_prompt != null) {
+    showToast("Sequence syntax is invalid", "Restore canonical Timeline sections with exact [start-end] boundaries before applying the sequence.");
+    return;
+  }
+  const choice = chooseContinuumSampler(app);
+  if (choice.status === "missing") {
+    showToast("Continuum sampler not found", "Add H3 Continuum Sampler V3.4–V3.7 to the current workflow.");
+    return;
+  }
+  if (choice.status === "multiple") {
+    showToast("Select a Continuum sampler", "Multiple compatible samplers are present. Select exactly one H3 Continuum Sampler V3.4–V3.7 on the canvas, then apply again.");
+    return;
+  }
+  let result;
+  try {
+    result = applySequenceToContinuum(app, choice.sampler, studio.continuumSequence, {
+      syncSettings,
+      mode: studio.mode,
+    });
+  } catch (error) {
+    showToast("Continuum conditioning could not be read", error.message);
+    return;
+  }
+  if (result.status === "apply_failed") {
+    showToast(
+      "Continuum apply failed",
+      "Writer restored the previous sampler settings and Sequence Prompt value after a graph widget callback failed.",
+      result.message || null,
+      null,
+      { dismissOnWorkspaceClick: true },
+    );
+    return;
+  }
+  if (result.status === "source_inventory_mismatch") {
+    showToast(
+      "Continuum conditioning changed",
+      "The selected H3 Continuum reference/keyframe sources differ from the inventory used to generate this sequence. Regenerate the sequence before applying it.",
+      null,
+      null,
+      { dismissOnWorkspaceClick: true },
+    );
+    return;
+  }
+  if (result.status === "mode_topology_mismatch") {
+    const required = result.mode_topology?.required || {};
+    const actual = result.mode_topology?.actual || {};
+    const describe = (value) => value.first_frame && value.last_frame
+      ? "First Frame + Last Frame"
+      : value.first_frame
+        ? "First Frame only"
+        : value.last_frame
+          ? "Last Frame only"
+          : "no First/Last keyframes";
+    const detail = result.mode_topology?.reason === "reference_images_require_reference_mode"
+      ? `T2VA cannot be applied to a sampler with ${actual.reference_images || 0} active Reference Image input(s). Switch to Reference mode or remove those inputs.`
+      : `${studio.mode} requires ${describe(required)}, while the selected H3 Continuum sampler currently has ${describe(actual)}. Rewire First/Last Frame or switch to the matching mode before applying.`;
+    showToast(
+      "Continuum mode does not match sampler",
+      detail,
+      null,
+      null,
+      { dismissOnWorkspaceClick: true },
+    );
+    return;
+  }
+  if (result.status === "reference_mismatch") {
+    const first = result.violations?.[0] || {};
+    const location = first.scope === "chunk"
+      ? `Chunk ${first.chunk_index}`
+      : "the shared preamble";
+    const tags = Array.isArray(first.tags) && first.tags.length
+      ? first.tags.join(", ")
+      : "a public reference tag";
+    const rule = first.kind === "undeclared"
+      ? "is not present in the selected H3 Continuum sampler conditioning inventory"
+      : "is outside the downstream conditioning scope for that part of the sequence";
+    showToast(
+      "Continuum reference scope is invalid",
+      `${location}: ${tags} ${rule}. Correct the Timeline or sampler reference wiring before applying.`,
+      null,
+      null,
+      { dismissOnWorkspaceClick: true },
+    );
+    return;
+  }
+  if (result.status === "mismatch") {
+    const detail = result.mismatches.map((item) => {
+      const label = item.field === "chunks" ? "Chunks" : item.field === "chunk_seconds" ? "Chunk seconds" : "Prompt Format";
+      return `${label}: Writer ${item.writer}, sampler ${item.sampler}`;
+    }).join(" · ");
+    showToast(
+      "Continuum settings differ",
+      detail,
+      null,
+      { label: "Sync settings & apply", onClick: () => applyCurrentSequence(true) },
+      { dismissOnWorkspaceClick: true },
+    );
+    return;
+  }
+  if (result.status === "unconnected" || result.status === "incompatible_source") {
+    try {
+      await navigator.clipboard.writeText(result.prompt);
+      showToast(
+        "Sequence copied",
+        result.status === "unconnected"
+          ? "Connect a Text (Multiline) node to Sequence Prompt, then paste the copied sequence into it."
+          : "Sequence Prompt is connected to a non-editable source. Connect a Text (Multiline) node and paste the copied sequence into it.",
+        null,
+        null,
+        { dismissOnWorkspaceClick: true },
+      );
+    } catch (error) {
+      showToast("Continuum handoff needs a text node", "Connect a Text (Multiline) node to Sequence Prompt and copy the sequence manually.", error.message);
+    }
+    return;
+  }
+  if (result.status !== "applied") {
+    showToast("Continuum handoff failed", "The selected node does not expose the required H3 Continuum sequence inputs.");
+    return;
+  }
+  saveCurrentModeDraft();
+  showToast("Sequence applied", `${continuumSamplerLabel(choice.sampler)} now has the canonical Timeline sequence with Prompt Format = Timeline.`);
 }
 
 function syncWorkspace() {
@@ -1012,17 +1518,31 @@ function syncWorkspace() {
     setMusicSystemPromptExpanded(false);
   }
   syncModeAvailability();
+  syncGenerationTarget();
+}
+
+function modeHasPromptWriterVisualMedia(mode) {
+  return studio.assets.some(
+    (asset) => asset.mode === mode && (asset.type === "image" || asset.type === "video"),
+  );
 }
 
 function syncModeAvailability() {
   if (!studio?.root) return;
   const textOnlyDirect = isTextOnlyDirectModel(studio.selectedModel);
   studio.root.querySelectorAll("[data-mode]").forEach((control) => {
-    const unavailable = !isGenerationModeAvailable(studio.selectedModel, control.dataset.mode);
+    const mode = control.dataset.mode;
+    const hasVisualMedia = modeHasPromptWriterVisualMedia(mode);
+    const unavailable = !isGenerationModeAvailable(studio.selectedModel, mode, {
+      generationTarget: studio.generationTarget,
+      hasVisualMedia,
+    });
     control.disabled = studio.requestBusy || unavailable;
     control.setAttribute("aria-disabled", String(control.disabled));
     control.title = unavailable && textOnlyDirect
-      ? "This Direct GGUF is text-only. Add its matching mmproj to enable visual modes."
+      ? studio.generationTarget === "continuum" && hasVisualMedia
+        ? "This Direct GGUF is text-only. Remove Prompt Writer image/video analysis media or add its matching mmproj; workflow-only Continuum conditioning does not require vision."
+        : "This Direct GGUF is text-only. Add its matching mmproj to enable this mode."
       : "";
   });
   studio.root.querySelectorAll("[data-workspace]").forEach((control) => {
@@ -1030,16 +1550,23 @@ function syncModeAvailability() {
     control.disabled = studio.requestBusy || unavailable;
     control.setAttribute("aria-disabled", String(control.disabled));
     control.title = unavailable
-      ? "This Direct GGUF is text-only. Only H3 Video · T2VA is available."
+      ? "This Direct GGUF is text-only. Music 3 is unavailable for this Direct model."
       : "";
   });
 }
 
-function generationModeIsAvailable() {
-  if (isGenerationModeAvailable(studio.selectedModel, studio.mode)) return true;
+function generationModeIsAvailable({ continuumRefinement = false } = {}) {
+  const hasVisualMedia = modeHasPromptWriterVisualMedia(studio.mode);
+  if (isGenerationModeAvailable(studio.selectedModel, studio.mode, {
+    generationTarget: studio.generationTarget,
+    hasVisualMedia,
+    continuumRefinement,
+  })) return true;
   showToast(
     "Text-only Direct GGUF",
-    "Use H3 Video · T2VA, or add the matching mmproj to enable visual modes.",
+    studio.generationTarget === "continuum" && hasVisualMedia && !continuumRefinement
+      ? "Remove Prompt Writer image/video analysis media to use workflow-only Continuum conditioning, or add the matching mmproj."
+      : "Use H3 Video · T2VA, or add the matching mmproj to enable visual analysis.",
   );
   return false;
 }
@@ -1125,6 +1652,7 @@ function setGenerationState(state, label, detail) {
   } else {
     studio.generationDotCount = 0;
   }
+  syncGenerationTarget();
 }
 
 function updatePromptResidency(status) {
@@ -1383,12 +1911,71 @@ async function startGenerationPreview() {
   const remote = external || apiProvider;
   markActiveWriterRequest();
   const generationDetail = external ? `${modelName} · the server may load its model if idle` : apiProvider ? `${modelName} · ${studio.selectedModel.api_preset}` : modelName;
-  setGenerationState("busy", remote ? "Contacting provider" : "Loading model", generationDetail);
+  const continuumRequest = studio.mode !== "Music3" && studio.generationTarget === "continuum";
+  let downstreamReferenceInventory = null;
+  if (continuumRequest) {
+    const target = chooseContinuumSampler(app);
+    if (target.status === "missing") {
+      showToast(
+        "Continuum sampler not found",
+        "Add H3 Continuum Sampler V3.4–V3.7 to the current workflow before generating so Writer can derive the authoritative keyframe and reference identities.",
+      );
+      studio.activeRequestFamily = null;
+      studio.activeRequestModelId = null;
+      return;
+    }
+    if (target.status === "multiple") {
+      showToast(
+        "Select a Continuum sampler",
+        "Multiple H3 Continuum Sampler V3.4–V3.7 nodes are present. Select exactly one target on the canvas before generating.",
+      );
+      studio.activeRequestFamily = null;
+      studio.activeRequestModelId = null;
+      return;
+    }
+    try {
+      downstreamReferenceInventory = bindActiveWorkflowReferenceMedia(
+        discoverContinuumReferenceInventory(app, target.sampler),
+      );
+    } catch (error) {
+      showToast("Continuum conditioning could not be read", error.message);
+      clearActiveWriterRequest();
+      return;
+    }
+    const modeTopology = validateContinuumModeTopology(studio.mode, downstreamReferenceInventory);
+    if (!modeTopology.valid) {
+      const required = modeTopology.required;
+      const actual = modeTopology.actual;
+      const describe = (value) => value.first_frame && value.last_frame
+        ? "First Frame + Last Frame"
+        : value.first_frame
+          ? "First Frame only"
+          : value.last_frame
+            ? "Last Frame only"
+            : "no First/Last keyframes";
+      const detail = modeTopology.reason === "reference_images_require_reference_mode"
+        ? `T2VA requires no First/Last keyframes and no Reference Images, while the selected H3 Continuum sampler has ${actual.reference_images} active Reference Image input(s). Choose Reference mode or remove those inputs.`
+        : `${studio.mode} requires ${describe(required)}, while the selected H3 Continuum sampler currently has ${describe(actual)}. Rewire First/Last Frame or choose the matching Prompt Writer mode.`;
+      showToast(
+        "Continuum mode does not match sampler",
+        detail,
+      );
+      studio.activeRequestFamily = null;
+      studio.activeRequestModelId = null;
+      return;
+    }
+  }
+  setGenerationState("busy", continuumRequest ? "Planning sequence" : remote ? "Contacting provider" : "Loading model", generationDetail);
   studio.statusTimer = setInterval(async () => {
     try {
       const status = await getStatus(studio.ollamaHost);
-      const labels = { loading_model: remote ? "Contacting provider" : "Loading model", processing_media: "Processing references", generating: "Generating", cancelling: "Cancelling" };
-      if (labels[status.phase]) setGenerationState("busy", labels[status.phase], generationDetail);
+      const labels = { loading_model: remote ? "Contacting provider" : "Loading model", processing_media: "Processing references", planning_sequence: "Planning sequence", generating_chunk: "Generating chunk", generating: "Generating", cancelling: "Cancelling" };
+      if (labels[status.phase]) {
+        const sequenceDetail = status.phase === "generating_chunk" && status.sequence_chunk_index
+          ? `Chunk ${status.sequence_chunk_index} of ${status.sequence_chunk_total} · ${generationDetail}`
+          : generationDetail;
+        setGenerationState("busy", labels[status.phase], sequenceDetail);
+      }
     } catch {}
   }, 650);
   try {
@@ -1396,8 +1983,14 @@ async function startGenerationPreview() {
       creativeBrief: currentBriefTextarea().value,
       lyrics: studio.mode === "Music3" ? studio.root.querySelector("[data-music-lyrics]").value : "",
       seed: newGenerationSeed(),
+      downstreamReferenceInventory,
     })));
     const output = studio.root.querySelector("[data-output]");
+    if (continuumRequest) {
+      studio.continuumSequence = sequenceStateFromResult(result);
+      studio.continuumChunks = studio.continuumSequence.settings.chunks;
+      studio.continuumChunkSeconds = studio.continuumSequence.settings.chunk_seconds;
+    }
     output.value = result.prompt;
     studio.lastModelPrompt = result.prompt;
     renderPromptHighlights();
@@ -1408,7 +2001,14 @@ async function startGenerationPreview() {
     saveCurrentModeDraft();
     studio.refineRestore = null;
     studio.root.querySelector("[data-refine-restore]").hidden = true;
-    if (result.thinking_fallback) {
+    syncGenerationTarget();
+    if (continuumRequest && result.planner_repair_attempted) {
+      showToast("Sequence generated", `The sequence plan needed one structural repair before ${studio.continuumChunks} chunks were written.`, null, null, { dismissOnWorkspaceClick: true });
+    } else if (continuumRequest) {
+      const providerRequests = result.provider_request_count ?? result.sequence_request_count ?? studio.continuumChunks + 1;
+      const requestCount = result.api_provider ? ` · ${providerRequests} API requests` : "";
+      showToast("Sequence generated", `${studio.continuumChunks} chunks · ${result.total_seconds.toFixed(1)}s${requestCount}`);
+    } else if (result.thinking_fallback) {
       showToast("Prompt completed", thinkingFallbackMessage(result, "final prompt"), null, null, { dismissOnWorkspaceClick: true });
     } else if (result.format_repair_applied) {
       const repairDetail = result.format_repair_multimodal
@@ -1978,7 +2578,7 @@ function renderInferenceSettings() {
       : runtimeRequirement.state === "update_required"
         ? renderDirectModelRuntimeUpdate(directModel)
         : isTextOnlyDirectModel(directModel)
-          ? `<div class="h3ps-direct-model-note"><strong>Text-only model · T2VA available</strong><span>${escapeHtml(directModel.capability_message || "No compatible vision projector is active.")}</span></div>`
+          ? `<div class="h3ps-direct-model-note"><strong>Text-only model · T2VA + workflow-only Continuum</strong><span>${escapeHtml(directModel.capability_message || "No compatible vision projector is active. Continuum can still use workflow-declared conditioning without Prompt Writer visual analysis.")}</span></div>`
           : "";
   } else {
     directStatus.innerHTML = "";
@@ -2068,7 +2668,16 @@ function selectSettingsProvider(provider) {
 function selectModel(model, { preserveSettingsProvider = false } = {}) {
   rememberRuntimePreferences();
   selectModelState(studio, model, { preserveSettingsProvider });
-  const switchedToT2VA = !isGenerationModeAvailable(model, studio.mode);
+  const hasVisualMedia = modeHasPromptWriterVisualMedia(studio.mode);
+  const savedContinuumRefinement = (
+    studio.generationTarget === "continuum"
+    && Boolean(studio.continuumSequence?.plan)
+  );
+  const switchedToT2VA = !isGenerationModeAvailable(model, studio.mode, {
+    generationTarget: studio.generationTarget,
+    hasVisualMedia,
+    continuumRefinement: savedContinuumRefinement,
+  });
   if (switchedToT2VA) {
     stashCurrentModeDraft();
     studio.mode = "T2VA";
@@ -2722,6 +3331,29 @@ async function submitRefinement() {
     showToast("Add a revision note", "Tell the model what should change in the current prompt.");
     return;
   }
+  const continuumRefinement = studio.mode !== "Music3" && studio.generationTarget === "continuum";
+  if (continuumRefinement) {
+    if (!studio.continuumSequence?.plan) {
+      showToast("No sequence plan", "Generate a Continuum sequence before refining one of its chunks.");
+      return;
+    }
+    try {
+      const parsed = parseContinuumTimeline(output.value, {
+        expectedChunks: studio.continuumChunks,
+        chunkSeconds: studio.continuumChunkSeconds,
+      });
+      studio.continuumSequence = {
+        ...studio.continuumSequence,
+        schema_version: 2,
+        preamble: parsed.preamble,
+        prompts: parsed.prompts,
+        raw_prompt: null,
+      };
+    } catch (error) {
+      showToast("Sequence syntax is invalid", error.message);
+      return;
+    }
+  }
   if (!studio.selectedModel) {
     showToast("No prompt model selected", "Choose a local model, connect llama.cpp, or configure an API provider.");
     return;
@@ -2730,15 +3362,76 @@ async function submitRefinement() {
     showToast("Model setup is incomplete", studio.selectedModel.setup_message || `Missing: ${studio.selectedModel.missing_dependencies.join(", ")}.`);
     return;
   }
-  if (!generationModeIsAvailable()) return;
+  if (!generationModeIsAvailable({ continuumRefinement })) return;
+  let downstreamReferenceInventory = null;
+  if (continuumRefinement) {
+    const target = chooseContinuumSampler(app);
+    if (target.status === "missing") {
+      showToast(
+        "Continuum sampler not found",
+        "Add H3 Continuum Sampler V3.4–V3.7 to the current workflow before refining so Writer can validate the saved Timeline against the active conditioning topology.",
+      );
+      return;
+    }
+    if (target.status === "multiple") {
+      showToast(
+        "Select a Continuum sampler",
+        "Multiple H3 Continuum Sampler V3.4–V3.7 nodes are present. Select exactly one target on the canvas before refining.",
+      );
+      return;
+    }
+    try {
+      downstreamReferenceInventory = bindActiveWorkflowReferenceMedia(
+        discoverContinuumReferenceInventory(app, target.sampler),
+      );
+    } catch (error) {
+      showToast("Continuum conditioning could not be read", error.message);
+      return;
+    }
+    if (
+      studio.continuumSequence?.downstream_reference_inventory
+      && !sameContinuumReferenceInventory(
+        studio.continuumSequence.downstream_reference_inventory,
+        downstreamReferenceInventory,
+      )
+    ) {
+      showToast(
+        "Continuum conditioning changed",
+        "The selected H3 Continuum reference/keyframe sources differ from the workflow inventory used to generate this saved sequence. Regenerate the sequence before refining it.",
+      );
+      return;
+    }
+    const modeTopology = validateContinuumModeTopology(studio.mode, downstreamReferenceInventory);
+    if (!modeTopology.valid) {
+      const required = modeTopology.required;
+      const actual = modeTopology.actual;
+      const describe = (value) => value.first_frame && value.last_frame
+        ? "First Frame + Last Frame"
+        : value.first_frame
+          ? "First Frame only"
+          : value.last_frame
+            ? "Last Frame only"
+            : "no First/Last keyframes";
+      const detail = modeTopology.reason === "reference_images_require_reference_mode"
+        ? `This T2VA sequence cannot be refined against a sampler with ${actual.reference_images} active Reference Image input(s). Restore the original T2VA topology or regenerate in Reference mode.`
+        : `${studio.mode} requires ${describe(required)}, while the selected H3 Continuum sampler currently has ${describe(actual)}. Restore the expected First/Last Frame wiring before refining this sequence.`;
+      showToast(
+        "Continuum mode does not match sampler",
+        detail,
+      );
+      return;
+    }
+  }
   if (!await prepareWriterRequest()) return;
 
   const previousPrompt = output.value;
+  const previousContinuumSequence = studio.continuumSequence;
   const previousMeta = studio.root.querySelector(".h3ps-editor-meta span:last-child").textContent;
   markActiveWriterRequest();
   submit.disabled = true;
   submit.innerHTML = `<span class="h3ps-spinner"></span>Refining…`;
-  setGenerationState("busy", "Refining prompt", studio.selectedModel.name.split("/").pop());
+  const selectedChunk = continuumRefinement ? Number(panel.querySelector("[data-refine-chunk]").value) : null;
+  setGenerationState("busy", continuumRefinement ? `Refining Chunk ${selectedChunk}` : "Refining prompt", studio.selectedModel.name.split("/").pop());
   try {
     const result = await vramHandoffCoordinator.trackWriterRequest(refine(buildRefinePayload(studio, {
       currentPrompt: previousPrompt,
@@ -2746,13 +3439,17 @@ async function submitRefinement() {
       creativeBrief: currentBriefTextarea().value.trim(),
       lyrics: studio.mode === "Music3" ? studio.root.querySelector("[data-music-lyrics]").value : "",
       seed: newGenerationSeed(),
+      chunkIndex: selectedChunk,
+      downstreamReferenceInventory,
     })));
     studio.refineRestore = {
       prompt: previousPrompt,
       meta: previousMeta,
       lastModelPrompt: studio.lastModelPrompt,
       lastModelMeta: studio.lastModelMeta,
+      continuumSequence: previousContinuumSequence,
     };
+    if (continuumRefinement) studio.continuumSequence = sequenceStateFromResult(result);
     output.value = result.prompt;
     studio.lastModelPrompt = result.prompt;
     renderPromptHighlights();
@@ -2765,7 +3462,9 @@ async function submitRefinement() {
     saveCurrentModeDraft();
     showToast(
       result.thinking_fallback ? "Rewrite completed" : "Prompt rewritten",
-      result.thinking_fallback
+      continuumRefinement
+        ? `Chunk ${selectedChunk} was rewritten; all other chunks were preserved byte-for-byte.`
+        : result.thinking_fallback
         ? thinkingFallbackMessage(result, "rewrite")
         : result.format_repair_applied
           ? result.format_repair_multimodal
@@ -2860,7 +3559,7 @@ function createStudio() {
         </nav>
         <div class="h3ps-output-toolbar">
           <span data-output-label>Generated prompt</span>
-          <div class="h3ps-output-badges"><button type="button" data-undo-edits hidden>Undo</button></div>
+          <div class="h3ps-output-badges"><span class="h3ps-continuum-badge" data-continuum-output-badge hidden></span><button type="button" data-undo-edits hidden>Undo</button></div>
         </div>
       </div>
 
@@ -2881,8 +3580,22 @@ function createStudio() {
           <p class="h3ps-section-hint" data-h3ps-mode-hint></p>
           <div class="h3ps-media" data-h3ps-media></div>
 
+          <div class="h3ps-generation-target" data-generation-target-control>
+            <span>Output target</span>
+            <div role="group" aria-label="Output target">
+              <button type="button" data-generation-target="single" aria-pressed="true">Single clip</button>
+              <button type="button" data-generation-target="continuum" aria-pressed="false">H3 Continuum</button>
+            </div>
+          </div>
+
+          <div class="h3ps-continuum-settings" data-continuum-settings hidden>
+            <label class="h3ps-field"><span>Chunks</span><input type="number" min="${CONTINUUM_MIN_CHUNKS}" max="${CONTINUUM_MAX_CHUNKS}" step="1" value="3" data-continuum-chunks></label>
+            <label class="h3ps-field"><span>Seconds per chunk</span><input type="number" min="${CONTINUUM_MIN_SECONDS}" max="${CONTINUUM_MAX_SECONDS}" step="0.5" value="5" data-continuum-seconds></label>
+            <strong data-continuum-total>15 seconds total</strong>
+          </div>
+
           <div class="h3ps-control-grid">
-            <label class="h3ps-field h3ps-duration-field"><span>Duration <b data-duration-label>10 seconds</b></span><div><input type="range" min="1" max="20" step="1" value="10" style="--h3ps-range:47.37%" data-duration-slider><i></i></div></label>
+            <label class="h3ps-field h3ps-duration-field" data-single-duration-field><span>Duration <b data-duration-label>10 seconds</b></span><div><input type="range" min="1" max="20" step="1" value="10" style="--h3ps-range:47.37%" data-duration-slider><i></i></div></label>
             <label class="h3ps-field h3ps-choice"><span>Aspect ratio</span><button type="button" data-choice-toggle="aspect"><b data-aspect-label>16:9</b><em data-aspect-description>Widescreen</em>${icon("chevron", 13)}</button><div class="h3ps-choice-menu h3ps-aspect-menu" data-choice-menu="aspect" hidden>${ASPECT_RATIOS.map(([value, label]) => `<button type="button" data-aspect="${value}"><b>${value}</b><em>${label}</em></button>`).join("")}</div></label>
           </div>
 
@@ -2958,6 +3671,7 @@ function createStudio() {
             <div class="h3ps-refine-heading">
               <span><strong data-refine-title>Refine prompt</strong><small><span data-refine-helper>Describe only what should change</span><em data-refine-media-note>No media re-upload</em></small></span>
               <div class="h3ps-refine-heading-actions">
+                <label class="h3ps-refine-chunk" data-refine-chunk-field hidden><span>Chunk</span><select data-refine-chunk></select></label>
                 <button type="button" class="h3ps-text-button" data-refine-restore hidden>Restore original</button>
                 <button type="button" class="h3ps-text-button" data-refine-cancel>Cancel</button>
                 <button type="button" class="h3ps-refine-submit" data-refine-submit>${icon("spark", 13)} Refine</button>
@@ -2968,6 +3682,7 @@ function createStudio() {
           <div class="h3ps-output-actions">
             <span class="h3ps-output-primary-actions">
               <button class="h3ps-secondary-button" type="button" title="Refine with local LLM" data-refine-toggle>${icon("spark", 15)} Refine</button>
+              <button class="h3ps-secondary-button" type="button" data-apply-continuum hidden>${icon("check", 15)} Apply to Continuum</button>
               <span class="h3ps-reference-insert" data-reference-insert hidden>
                 <button class="h3ps-reference-insert-toggle" type="button" title="Insert reference" aria-label="Insert reference" aria-haspopup="menu" aria-expanded="false" data-reference-insert-toggle></button>
                 <span class="h3ps-reference-insert-popover" data-reference-insert-popover role="menu" hidden></span>
@@ -3100,6 +3815,38 @@ function createStudio() {
     clearEverything();
   });
   root.querySelector("[data-generate]").addEventListener("click", startGenerationPreview);
+  root.querySelectorAll("[data-generation-target]").forEach((button) => button.addEventListener("click", () => {
+    setGenerationTarget(button.dataset.generationTarget);
+  }));
+  const updateContinuumSettings = () => {
+    const chunksInput = root.querySelector("[data-continuum-chunks]");
+    const secondsInput = root.querySelector("[data-continuum-seconds]");
+    const chunks = Number(chunksInput.value);
+    const seconds = Number(secondsInput.value);
+    if (!Number.isInteger(chunks) || chunks < CONTINUUM_MIN_CHUNKS || chunks > CONTINUUM_MAX_CHUNKS || !Number.isFinite(seconds) || seconds < CONTINUUM_MIN_SECONDS || seconds > CONTINUUM_MAX_SECONDS) {
+      showToast("Invalid Continuum settings", `Use ${CONTINUUM_MIN_CHUNKS}–${CONTINUUM_MAX_CHUNKS} chunks and ${CONTINUUM_MIN_SECONDS}–${CONTINUUM_MAX_SECONDS} seconds per chunk.`);
+      syncGenerationTarget();
+      return;
+    }
+    const invalidatesSequence = studio.continuumSequence?.plan
+      && (studio.continuumSequence.settings.chunks !== chunks
+        || Math.abs(studio.continuumSequence.settings.chunk_seconds - seconds) > 1e-6);
+    studio.continuumChunks = chunks;
+    studio.continuumChunkSeconds = seconds;
+    if (invalidatesSequence) {
+      studio.continuumSequence = null;
+      root.querySelector("[data-output]").value = "";
+      studio.lastModelPrompt = "";
+      studio.lastModelMeta = promptLengthMeta("");
+      root.querySelector(".h3ps-editor-meta span:last-child").textContent = studio.lastModelMeta;
+      showToast("Sequence settings changed", "Generate a new sequence for the updated chunk settings.");
+    }
+    syncGenerationTarget();
+    saveCurrentModeDraft();
+    saveUserPreferences(localStorage, studio);
+  };
+  root.querySelector("[data-continuum-chunks]").addEventListener("change", updateContinuumSettings);
+  root.querySelector("[data-continuum-seconds]").addEventListener("change", updateContinuumSettings);
   root.querySelector("[data-restore-default-drafts]").addEventListener("click", restoreDefaultDrafts);
   root.querySelector("[data-comfy-memory-action]").addEventListener("click", () => releaseComfyVram());
   root.querySelector("[data-guide-toggle]").addEventListener("click", async () => {
@@ -3363,6 +4110,7 @@ function createStudio() {
     if (!root.querySelector("[data-other-models-popover]").hidden) positionOtherModelsPopover();
   });
   root.querySelector("[data-refine-toggle]").addEventListener("click", () => toggleRefine(root.querySelector("[data-refine-panel]").hidden));
+  root.querySelector("[data-apply-continuum]").addEventListener("click", () => applyCurrentSequence());
   root.querySelector("[data-refine-cancel]").addEventListener("click", () => toggleRefine(false));
   root.querySelector("[data-refine-submit]").addEventListener("click", submitRefinement);
   root.querySelector("[data-lyrics-refine-toggle]").addEventListener("click", () => {
@@ -3395,6 +4143,7 @@ function createStudio() {
     if (studio.refineRestore == null) return;
     const output = root.querySelector("[data-output]");
     output.value = studio.refineRestore.prompt;
+    studio.continuumSequence = studio.refineRestore.continuumSequence || studio.continuumSequence;
     studio.lastModelPrompt = studio.refineRestore.lastModelPrompt;
     studio.lastModelMeta = studio.refineRestore.lastModelMeta;
     renderPromptHighlights();
@@ -3402,6 +4151,7 @@ function createStudio() {
     studio.refineRestore = null;
     root.querySelector("[data-refine-restore]").hidden = true;
     syncModifiedState();
+    syncGenerationTarget();
     saveCurrentModeDraft();
     showToast("Previous prompt restored", "The AI rewrite was discarded.");
   });
@@ -3418,7 +4168,8 @@ function createStudio() {
   root.querySelector("[data-copy]").addEventListener("click", async () => {
     try {
       await navigator.clipboard.writeText(root.querySelector("[data-output]").value);
-      showToast(studio.mode === "Music3" ? "Caption copied" : "Prompt copied", studio.mode === "Music3" ? "The generated Music 3 caption is on your clipboard." : "The generated H3 prompt is on your clipboard.");
+      const continuum = studio.mode !== "Music3" && studio.generationTarget === "continuum";
+      showToast(studio.mode === "Music3" ? "Caption copied" : continuum ? "Sequence copied" : "Prompt copied", studio.mode === "Music3" ? "The generated Music 3 caption is on your clipboard." : continuum ? "The canonical Continuum Timeline sequence is on your clipboard." : "The generated H3 prompt is on your clipboard.");
     } catch (error) {
       showToast("Copy failed", "Clipboard access was denied.", error.message);
     }

--- a/web/skin.css
+++ b/web/skin.css
@@ -116,6 +116,11 @@
 .h3ps-section-hint { color: #686871; }
 
 /* Media */
+.h3ps-workflow-references { border-color: #27272c; background: #111113; }
+.h3ps-workflow-reference-row { background: #0f0f11; }
+.h3ps-workflow-reference-thumb { border-color: #28282d; background: #0a0a0c; }
+.h3ps-workflow-reference-row > button { border-color: #2b2b31; background: #17171b; color: #bdbdc3; }
+.h3ps-workflow-reference-row > button:hover:not(:disabled) { border-color: #3b3b43; background: #1c1c20; color: var(--h3ps-text); }
 .h3ps-media-filters button { color: #72727b; }
 .h3ps-media-filters button:hover { background: #131315; color: #bdbdc3; }
 .h3ps-media-filters button.is-active {

--- a/web/studio_state.js
+++ b/web/studio_state.js
@@ -29,8 +29,18 @@ export function isTextOnlyDirectModel(model) {
   return model?.family === "gguf" && model?.capabilities?.images === false;
 }
 
-export function isGenerationModeAvailable(model, mode) {
-  return !isTextOnlyDirectModel(model) || mode === "T2VA";
+export function isGenerationModeAvailable(
+  model,
+  mode,
+  {
+    generationTarget = "single",
+    hasVisualMedia = false,
+    continuumRefinement = false,
+  } = {},
+) {
+  if (!isTextOnlyDirectModel(model) || mode === "T2VA") return true;
+  if (mode === "Music3" || generationTarget !== "continuum") return false;
+  return continuumRefinement || !hasVisualMedia;
 }
 
 export function isModeDraftDirty(mode, draft, defaults) {
@@ -49,7 +59,10 @@ export function resetModeDraft(drafts, mode) {
 }
 
 export function clearPromptDraft(draft = {}) {
-  return { ...draft, brief: "", prompt: "" };
+  const cleared = { ...draft, brief: "", prompt: "" };
+  if (Object.prototype.hasOwnProperty.call(draft, "single_prompt")) cleared.single_prompt = "";
+  if (Object.prototype.hasOwnProperty.call(draft, "continuum")) cleared.continuum = null;
+  return cleared;
 }
 
 export function normalizeCustomFrameCount(value) {
@@ -60,12 +73,22 @@ export function normalizeCustomFrameCount(value) {
 export function loadModeDrafts(storage = globalThis.localStorage) {
   try {
     const value = JSON.parse(storage?.getItem(MODE_DRAFTS_STORAGE_KEY) || "null");
-    if (!value || value.version !== 1 || !value.drafts || typeof value.drafts !== "object") return {};
+    if (!value || ![1, 2].includes(value.version) || !value.drafts || typeof value.drafts !== "object") return {};
     return Object.fromEntries(DRAFT_MODES.flatMap((mode) => {
       const draft = value.drafts[mode];
       if (!draft || typeof draft.brief !== "string" || typeof draft.prompt !== "string") return [];
       const briefLimit = mode === "Music3" ? 2000 : 8000;
-      const safeDraft = { brief: draft.brief.slice(0, briefLimit), prompt: draft.prompt.slice(0, 16000) };
+      const legacy = value.version === 1;
+      const generationTarget = !legacy && draft.generation_target === "continuum" && mode !== "Music3" ? "continuum" : "single";
+      const singlePrompt = typeof draft.single_prompt === "string" ? draft.single_prompt : draft.prompt;
+      const continuum = !legacy && mode !== "Music3" ? safeContinuumDraft(draft.continuum) : null;
+      const safeDraft = {
+        brief: draft.brief.slice(0, briefLimit),
+        prompt: generationTarget === "continuum" ? "" : singlePrompt.slice(0, 20000),
+        single_prompt: singlePrompt.slice(0, 20000),
+        generation_target: generationTarget,
+        continuum,
+      };
       if (mode === "Music3") safeDraft.lyrics = typeof draft.lyrics === "string" ? draft.lyrics.slice(0, 4000) : "";
       return [[mode, safeDraft]];
     }));
@@ -74,24 +97,136 @@ export function loadModeDrafts(storage = globalThis.localStorage) {
   }
 }
 
+function safeContinuumInventory(value) {
+  if (value == null) return { valid: true, value: null };
+  if (!value || typeof value !== "object" || Number(value.schema_version ?? 1) !== 1 || !Array.isArray(value.items)) {
+    return { valid: false, value: null };
+  }
+  if (value.items.length > 13) return { valid: false, value: null };
+
+  const roles = new Set(["reference_image", "first_frame", "last_frame", "video_reference", "driving_audio"]);
+  const singletonRoles = new Set();
+  const items = [];
+  for (const raw of value.items) {
+    if (!raw || typeof raw !== "object" || !roles.has(raw.role)) return { valid: false, value: null };
+    if (raw.role !== "reference_image") {
+      if (singletonRoles.has(raw.role)) return { valid: false, value: null };
+      singletonRoles.add(raw.role);
+    }
+    if (typeof raw.kind !== "string" || raw.kind.length > 32) return { valid: false, value: null };
+    if (typeof raw.source !== "string" || raw.source.length > 32) return { valid: false, value: null };
+    if (typeof raw.visible_to_model !== "boolean") return { valid: false, value: null };
+    const item = {
+      role: raw.role,
+      kind: raw.kind,
+      source: raw.source,
+      visible_to_model: raw.visible_to_model,
+    };
+    for (const field of ["tag", "input_name", "source_node_class", "source_output_name", "source_identity", "model_asset_id"]) {
+      if (raw[field] != null) {
+        if (typeof raw[field] !== "string" || raw[field].length > 512) {
+          return { valid: false, value: null };
+        }
+        item[field] = raw[field];
+      }
+    }
+    if (raw.source_node_id != null) {
+      if (typeof raw.source_node_id === "number") {
+        if (!Number.isSafeInteger(raw.source_node_id)) return { valid: false, value: null };
+      } else if (typeof raw.source_node_id === "string") {
+        if (!raw.source_node_id || raw.source_node_id.length > 512) return { valid: false, value: null };
+      } else {
+        return { valid: false, value: null };
+      }
+      item.source_node_id = raw.source_node_id;
+    }
+    if (raw.source_slot != null) {
+      if (!Number.isInteger(raw.source_slot) || raw.source_slot < 0) return { valid: false, value: null };
+      item.source_slot = raw.source_slot;
+    }
+    items.push(item);
+  }
+  return { valid: true, value: { schema_version: 1, items } };
+}
+
+function safeContinuumDraft(value) {
+  if (!value || ![1, 2].includes(value.schema_version) || !value.settings || typeof value.settings !== "object") return null;
+  const chunks = Number(value.settings.chunks);
+  const chunkSeconds = Number(value.settings.chunk_seconds);
+  if (!Number.isInteger(chunks) || chunks < 1 || chunks > 16 || !Number.isFinite(chunkSeconds) || chunkSeconds < 4 || chunkSeconds > 30) return null;
+  if (
+    !Array.isArray(value.prompts)
+    || value.prompts.length !== chunks
+    || value.prompts.some((prompt) => typeof prompt !== "string" || !prompt.trim() || prompt.length > 20000)
+  ) return null;
+
+  let plan = null;
+  try {
+    const serializedPlan = JSON.stringify(value.plan ?? null);
+    if (serializedPlan.length <= 100000) plan = JSON.parse(serializedPlan);
+  } catch {}
+  if (!plan || typeof plan !== "object") return null;
+
+  const inventory = safeContinuumInventory(value.downstream_reference_inventory);
+  if (!inventory.valid) return null;
+
+  const preambleSource = typeof value.preamble === "string"
+    ? value.preamble
+    : typeof plan?.global?.sequence_preamble === "string"
+      ? plan.global.sequence_preamble
+      : "";
+  if (preambleSource.length > 20000) return null;
+  if (typeof value.raw_prompt === "string" && value.raw_prompt.length > 320000) return null;
+  const result = {
+    schema_version: 2,
+    settings: {
+      schema_version: 2,
+      chunks,
+      chunk_seconds: chunkSeconds,
+      total_seconds: Number((chunks * chunkSeconds).toFixed(12)),
+    },
+    plan,
+    preamble: preambleSource,
+    prompts: [...value.prompts],
+    downstream_reference_inventory: inventory.value,
+    raw_prompt: typeof value.raw_prompt === "string" ? value.raw_prompt : null,
+  };
+  if (value.schema_version === 1 || value.migrated_from_schema_version === 1) {
+    result.migrated_from_schema_version = 1;
+  }
+  if (result.raw_prompt != null && typeof value.timeline_error === "string") {
+    result.timeline_error = value.timeline_error.slice(0, 4000);
+  }
+  return result;
+}
+
 export function saveModeDrafts(storage, drafts) {
   const safeDrafts = Object.fromEntries(DRAFT_MODES.flatMap((mode) => {
     const draft = drafts?.[mode];
     if (!draft || typeof draft.brief !== "string" || typeof draft.prompt !== "string") return [];
     const briefLimit = mode === "Music3" ? 2000 : 8000;
-    const safeDraft = { brief: draft.brief.slice(0, briefLimit), prompt: draft.prompt.slice(0, 16000) };
+    const generationTarget = draft.generation_target === "continuum" && mode !== "Music3" ? "continuum" : "single";
+    const singlePrompt = typeof draft.single_prompt === "string" ? draft.single_prompt : draft.prompt;
+    const continuum = safeContinuumDraft(draft.continuum);
+    const safeDraft = {
+      brief: draft.brief.slice(0, briefLimit),
+      prompt: generationTarget === "single" ? String(singlePrompt || "").slice(0, 20000) : "",
+      single_prompt: String(singlePrompt || "").slice(0, 20000),
+      generation_target: generationTarget,
+      continuum,
+    };
     if (mode === "Music3") safeDraft.lyrics = typeof draft.lyrics === "string" ? draft.lyrics.slice(0, 4000) : "";
     return [[mode, safeDraft]];
   }));
-  storage?.setItem(MODE_DRAFTS_STORAGE_KEY, JSON.stringify({ version: 1, drafts: safeDrafts }));
+  storage?.setItem(MODE_DRAFTS_STORAGE_KEY, JSON.stringify({ version: 2, drafts: safeDrafts }));
 }
 
 export function loadUserPreferences(storage = globalThis.localStorage) {
   try {
     const value = JSON.parse(storage?.getItem(USER_PREFERENCES_STORAGE_KEY) || "null");
-    if (!value || value.version !== 1) return null;
+    if (!value || ![1, 2].includes(value.version)) return null;
     return {
-      version: 1,
+      version: 2,
       mode: MODES.includes(value.mode) ? value.mode : "Reference",
       duration_seconds: Number.isInteger(value.duration_seconds) && value.duration_seconds >= 1 && value.duration_seconds <= 20 ? value.duration_seconds : 10,
       aspect_ratio: ASPECT_RATIOS.includes(value.aspect_ratio) ? value.aspect_ratio : "16:9",
@@ -106,6 +241,9 @@ export function loadUserPreferences(storage = globalThis.localStorage) {
       music_lyrics_use_brief: value.music_lyrics_use_brief !== false,
       fullscreen: value.fullscreen === true,
       vram_handoff: value.vram_handoff === true,
+      generation_target: value.generation_target === "continuum" ? "continuum" : "single",
+      continuum_chunks: Number.isInteger(value.continuum_chunks) && value.continuum_chunks >= 1 && value.continuum_chunks <= 16 ? value.continuum_chunks : 3,
+      continuum_chunk_seconds: Number.isFinite(value.continuum_chunk_seconds) && value.continuum_chunk_seconds >= 4 && value.continuum_chunk_seconds <= 30 ? value.continuum_chunk_seconds : 5,
     };
   } catch {
     return null;
@@ -114,7 +252,7 @@ export function loadUserPreferences(storage = globalThis.localStorage) {
 
 export function saveUserPreferences(storage, state) {
   const safe = {
-    version: 1,
+    version: 2,
     mode: MODES.includes(state.mode) ? state.mode : "Reference",
     duration_seconds: Number.isInteger(state.durationSeconds) && state.durationSeconds >= 1 && state.durationSeconds <= 20 ? state.durationSeconds : 10,
     aspect_ratio: ASPECT_RATIOS.includes(state.aspectRatio) ? state.aspectRatio : "16:9",
@@ -129,6 +267,9 @@ export function saveUserPreferences(storage, state) {
     music_lyrics_use_brief: state.musicLyricsUseBrief !== false,
     fullscreen: state.fullscreen === true,
     vram_handoff: state.vramHandoff === true,
+    generation_target: state.generationTarget === "continuum" ? "continuum" : "single",
+    continuum_chunks: Number.isInteger(state.continuumChunks) && state.continuumChunks >= 1 && state.continuumChunks <= 16 ? state.continuumChunks : 3,
+    continuum_chunk_seconds: Number.isFinite(state.continuumChunkSeconds) && state.continuumChunkSeconds >= 4 && state.continuumChunkSeconds <= 30 ? state.continuumChunkSeconds : 5,
   };
   storage?.setItem(USER_PREFERENCES_STORAGE_KEY, JSON.stringify(safe));
 }
@@ -325,6 +466,7 @@ function sharedInferencePayload(state) {
   return {
     session_id: state.sessionId,
     mode: state.mode,
+    generation_target: state.mode !== "Music3" ? state.generationTarget : "single",
     model_id: state.selectedModel?.id,
     external_server: selectedExternalServer(state),
     ollama_model: selectedOllamaModel(state),
@@ -343,7 +485,7 @@ function sharedInferencePayload(state) {
   };
 }
 
-export function buildGeneratePayload(state, { creativeBrief, lyrics = "", seed }) {
+export function buildGeneratePayload(state, { creativeBrief, lyrics = "", seed, downstreamReferenceInventory = null }) {
   const directRuntime = state.selectedModel?.family === "gguf";
   const thinking = state.selectedModel?.family === "external" ? false : state.thinking;
   const generationBudgetMode = state.generationBudget || "auto";
@@ -353,7 +495,8 @@ export function buildGeneratePayload(state, { creativeBrief, lyrics = "", seed }
   const payload = {
     session_id: state.sessionId,
     mode: state.mode,
-    duration_seconds: state.durationSeconds,
+    generation_target: state.mode !== "Music3" ? state.generationTarget : "single",
+    duration_seconds: state.generationTarget === "continuum" && state.mode !== "Music3" ? state.continuumChunkSeconds : state.durationSeconds,
     aspect_ratio: state.aspectRatio,
     creative_brief: creativeBrief,
     model_id: state.selectedModel?.id,
@@ -373,20 +516,45 @@ export function buildGeneratePayload(state, { creativeBrief, lyrics = "", seed }
     seed,
     unload_after: !state.keepModelLoaded,
   };
+  if (state.generationTarget === "continuum" && state.mode !== "Music3") {
+    payload.continuum = {
+      schema_version: 2,
+      chunks: state.continuumChunks,
+      chunk_seconds: state.continuumChunkSeconds,
+    };
+    if (downstreamReferenceInventory != null) {
+      payload.downstream_reference_inventory = downstreamReferenceInventory;
+    }
+  }
   if (state.mode === "Music3") payload.lyrics = lyrics;
   return payload;
 }
 
-export function buildRefinePayload(state, { currentPrompt, instruction, creativeBrief, lyrics = "", seed }) {
+export function buildRefinePayload(state, { currentPrompt, instruction, creativeBrief, lyrics = "", seed, chunkIndex = null, downstreamReferenceInventory = null }) {
   const payload = {
     ...sharedInferencePayload(state),
     current_prompt: currentPrompt,
     instruction,
-    duration_seconds: state.durationSeconds,
+    duration_seconds: state.generationTarget === "continuum" && state.mode !== "Music3" ? state.continuumChunkSeconds : state.durationSeconds,
     aspect_ratio: state.aspectRatio,
     creative_brief: creativeBrief,
     seed,
   };
+  if (state.generationTarget === "continuum" && state.mode !== "Music3") {
+    payload.continuum = {
+      schema_version: 2,
+      chunks: state.continuumChunks,
+      chunk_seconds: state.continuumChunkSeconds,
+      chunk_index: chunkIndex,
+      plan: state.continuumSequence?.plan || null,
+      ...(state.continuumSequence?.downstream_reference_inventory
+        ? { downstream_reference_inventory: state.continuumSequence.downstream_reference_inventory }
+        : {}),
+    };
+    if (downstreamReferenceInventory != null) {
+      payload.downstream_reference_inventory = downstreamReferenceInventory;
+    }
+  }
   if (state.mode === "Music3") payload.lyrics = lyrics;
   return payload;
 }
@@ -418,6 +586,10 @@ export function createStudioState({ sessionId, storage = globalThis.localStorage
     lastVideoMode: preferences?.mode && preferences.mode !== "Music3" ? preferences.mode : "Reference",
     mediaFilter: "all",
     durationSeconds: preferences?.duration_seconds || 10,
+    generationTarget: preferences?.generation_target || "single",
+    continuumChunks: preferences?.continuum_chunks || 3,
+    continuumChunkSeconds: preferences?.continuum_chunk_seconds || 5,
+    continuumSequence: null,
     aspectRatio: preferences?.aspect_ratio || "16:9",
     contextProfile: "auto",
     contextTokens: null,
@@ -458,6 +630,8 @@ export function createStudioState({ sessionId, storage = globalThis.localStorage
     generationDotCount: 0,
     sessionId,
     assets: [],
+    workflowReferenceBindings: {},
+    workflowReferenceImportBusy: false,
     previewAssetId: null,
     audioSupported: false,
     models: [],

--- a/web/styles.css
+++ b/web/styles.css
@@ -97,6 +97,30 @@ body.h3ps-modal-open { overflow: hidden; }
 .h3ps-section-hint { min-height: 17px; margin: 4px 0 10px; color: var(--h3ps-muted); font-size: 11.5px; }
 
 .h3ps-media { min-height: 150px; }
+.h3ps-workflow-references { margin: -2px 0 10px; padding: 9px; border: 1px solid var(--h3ps-border); border-radius: 9px; background: var(--h3ps-surface-2); }
+.h3ps-workflow-references > header { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 7px; }
+.h3ps-workflow-references > header > span:first-child { display: flex; flex-direction: column; min-width: 0; }
+.h3ps-workflow-references > header strong { font-size: 10.5px; font-weight: 650; }
+.h3ps-workflow-references > header small { margin-top: 1px; color: var(--h3ps-muted); font-size: 9px; line-height: 1.35; }
+.h3ps-workflow-reference-actions { display: flex; align-items: center; gap: 9px; flex: 0 0 auto; }
+.h3ps-workflow-add-all { height: 28px; padding: 0 9px; font-size: 9.5px; }
+.h3ps-workflow-add-all:disabled { opacity: .48; cursor: default; }
+.h3ps-workflow-reference-list { display: flex; flex-direction: column; gap: 5px; }
+.h3ps-workflow-reference-row { display: grid; grid-template-columns: 32px minmax(0,1fr) auto auto; align-items: center; gap: 7px; min-height: 38px; padding: 3px 4px 3px 3px; border: 1px solid transparent; border-radius: 7px; background: rgba(255,255,255,.018); }
+.h3ps-workflow-reference-row.is-bound { border-color: rgba(99,212,155,.18); background: rgba(99,212,155,.035); }
+.h3ps-workflow-reference-row.is-stale { border-color: rgba(255,178,71,.2); background: rgba(255,178,71,.035); }
+.h3ps-workflow-reference-thumb { display: grid; place-items: center; width: 32px; height: 32px; overflow: hidden; border: 1px solid var(--h3ps-border); border-radius: 6px; background: #101216; color: var(--h3ps-muted); }
+.h3ps-workflow-reference-thumb img { width: 100%; height: 100%; object-fit: cover; }
+.h3ps-workflow-reference-copy { display: flex; flex-direction: column; min-width: 0; }
+.h3ps-workflow-reference-copy strong { overflow: hidden; font-size: 9.5px; font-family: ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; font-weight: 620; white-space: nowrap; text-overflow: ellipsis; }
+.h3ps-workflow-reference-copy small { overflow: hidden; margin-top: 1px; color: var(--h3ps-muted); font-size: 8.5px; white-space: nowrap; text-overflow: ellipsis; }
+.h3ps-workflow-reference-row > em { color: var(--h3ps-muted); font-size: 8.5px; font-style: normal; white-space: nowrap; }
+.h3ps-workflow-reference-row.is-bound > em { color: #79cfa6; }
+.h3ps-workflow-reference-row.is-stale > em { color: #d8ae68; }
+.h3ps-workflow-reference-row > button { min-width: 61px; height: 25px; padding: 0 7px; border: 1px solid var(--h3ps-border); border-radius: 6px; background: #202329; color: #d7d9dd; font-size: 9px; cursor: pointer; }
+.h3ps-workflow-reference-row > button:hover:not(:disabled) { border-color: #4c525d; background: #262a31; }
+.h3ps-workflow-reference-row > button:disabled { opacity: .45; cursor: default; }
+.h3ps-workflow-reference-empty { margin: 2px 0 0; color: var(--h3ps-muted); font-size: 9.5px; line-height: 1.4; }
 .h3ps-media-filters { display: flex; align-items: center; gap: 5px; margin: -2px 0 8px; }
 .h3ps-media-filters button { display: inline-flex; align-items: center; gap: 5px; height: 25px; padding: 0 8px; border: 1px solid transparent; border-radius: 6px; background: transparent; color: var(--h3ps-muted); font-size: 9.5px; cursor: pointer; }
 .h3ps-media-filters button b { color: var(--h3ps-dim); font-size: 9px; font-weight: 560; }
@@ -153,6 +177,8 @@ body.h3ps-modal-open { overflow: hidden; }
 .h3ps-empty-drop strong { font-size: 11.5px; }.h3ps-empty-drop small { margin-top: 2px; color: var(--h3ps-muted); font-size: 10px; }
 
 .h3ps-control-grid { display: grid; grid-template-columns: 1fr 1.25fr; gap: 10px; margin-top: 13px; }
+.h3ps-generation-target { display:flex; align-items:center; justify-content:space-between; gap:10px; margin-top:13px; }.h3ps-generation-target[hidden] { display:none; }.h3ps-generation-target > span { color:#b9bdc5; font-size:10px; font-weight:650; letter-spacing:.035em; text-transform:uppercase; }.h3ps-generation-target > div { display:flex; padding:2px; border:1px solid var(--h3ps-border); border-radius:7px; background:#1b1e23; }.h3ps-generation-target button { min-height:27px; padding:0 10px; border:0; border-radius:5px; background:transparent; color:var(--h3ps-muted); font-size:9.5px; cursor:pointer; }.h3ps-generation-target button.is-active { background:#30343b; color:#fff; box-shadow:inset 2px 0 var(--h3ps-accent-strong); }.h3ps-generation-target button:disabled { opacity:.52; cursor:default; }
+.h3ps-continuum-settings { display:grid; grid-template-columns:1fr 1.35fr auto; align-items:end; gap:9px; margin-top:9px; padding:9px; border:1px solid var(--h3ps-border-soft); border-radius:8px; background:#1b1e23; }.h3ps-continuum-settings[hidden] { display:none; }.h3ps-continuum-settings input { width:100%; height:31px; padding:0 9px; border:1px solid var(--h3ps-border); border-radius:6px; outline:none; background:#202329; color:var(--h3ps-text); font-size:10.5px; }.h3ps-continuum-settings input:focus { border-color:rgba(255,115,86,.62); }.h3ps-continuum-settings > strong { align-self:center; margin-top:15px; color:var(--h3ps-muted); font-size:9.5px; font-weight:570; white-space:nowrap; }
 .h3ps-field { display: flex; flex-direction: column; gap: 6px; }
 .h3ps-choice { position: relative; }
 .h3ps-field > span, .h3ps-brief > span strong { color: #b9bdc5; font-size: 10px; font-weight: 650; letter-spacing: .035em; text-transform: uppercase; }
@@ -400,6 +426,7 @@ body.h3ps-modal-open { overflow: hidden; }
 .h3ps-draft-defaults-action { display:flex; justify-content:flex-end; max-width:620px; padding-top:11px; }.h3ps-draft-defaults-action button { display:inline-flex; align-items:center; gap:6px; min-height:28px; padding:0 9px; border:1px solid var(--h3ps-border); border-radius:6px; background:#141416; color:var(--h3ps-muted); font-size:9.5px; cursor:pointer; }.h3ps-draft-defaults-action button:hover { border-color:#38383f; color:var(--h3ps-text); }
 
 .h3ps-output-badges { display: flex; gap: 5px; text-transform:none; letter-spacing:0; }.h3ps-output-badges button { padding: 3px 7px; border: 1px solid var(--h3ps-border); border-radius: 5px; background: transparent; color: var(--h3ps-muted); font-size: 9px; cursor: pointer; }.h3ps-output-badges button:hover { border-color: #555b66; color: var(--h3ps-text); }
+.h3ps-continuum-badge { padding:3px 7px; border:1px solid rgba(255,115,86,.28); border-radius:5px; background:rgba(255,115,86,.08); color:#e9a797; font-size:9px; }
 .h3ps-editor-wrap { position: relative; flex: 1; min-height: 310px; overflow: hidden; border: 1px solid var(--h3ps-border); border-radius: 9px; background: #1b1e23; }
 .h3ps-output-panel.is-refining .h3ps-editor-wrap { min-height: 205px; }
 .h3ps-editor-highlight { position: absolute; inset: 0; z-index: 2; min-height: 310px; overflow: hidden; padding: 17px 18px 64px; color: transparent; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 11.5px; line-height: 1.68; white-space: pre-wrap; overflow-wrap: break-word; pointer-events: none; }
@@ -447,6 +474,7 @@ body.h3ps-modal-open { overflow: hidden; }
 .h3ps-refine-heading small { display: flex; gap: 7px; margin-top: 1px; color: var(--h3ps-muted); font-size: 9px; }
 .h3ps-refine-heading small em { color: var(--h3ps-dim); font-size: 8.5px; font-style: normal; }
 .h3ps-refine-heading-actions { display: flex; align-items: center; gap: 7px; margin-left: 12px; }
+.h3ps-refine-chunk { display:flex; align-items:center; gap:5px; color:var(--h3ps-muted); font-size:9px; }.h3ps-refine-chunk select { height:27px; padding:0 20px 0 7px; border:1px solid var(--h3ps-border); border-radius:5px; background:#22252b; color:var(--h3ps-text); font-size:9px; }
 .h3ps-refine textarea { width: 100%; height: 49px; resize: none; padding: 8px 9px; border: 1px solid var(--h3ps-border); border-radius: 6px; outline: none; background: #22252b; color: #e1e3e7; font-size: 10.5px; line-height: 1.4; scrollbar-width: none; }
 .h3ps-refine[data-refine-panel] textarea { min-height: 72px; max-height: min(600px, 50dvh); resize: vertical; }
 .h3ps-refine textarea::-webkit-scrollbar { display: none; }


### PR DESCRIPTION
## Summary

Add native **H3 Continuum** prompt generation to MiniMax H3 Prompt Writer, including sequence planning, canonical Timeline output, workflow-aware reference identities, chunk-local refinement, direct graph handoff, cross-repository compatibility testing, and the reliability work required to keep generated sequences aligned with the actual Continuum workflow.

This contribution is aligned with the current official **H3 Continuum Sampler V3.4–V3.7** contract and preserves the existing single-prompt T2VA, I2VA, FL2VA, L2VA, Reference, and Music 3 paths.

It also includes a required **LM Studio Custom-provider fix** discovered during integration testing: local LM Studio instances on a private LAN can now receive the same automatic LM Studio metadata/capability handling as loopback instances.

## H3 Continuum generation

H3 Continuum is added as a separate **generation target**, rather than another MiniMax H3 media mode.

Users can select normal single-prompt generation or H3 Continuum while retaining the existing H3 mode semantics.

Continuum generation supports:

* **1–16 chunks**
* native Continuum chunk durations from **4–30 seconds**
* **5–15 seconds recommended** for normal use
* one shared sequence-wide H3 preamble
* canonical Continuum Timeline sections such as:

  * `[0-5s]`
  * `[5-10s]`
  * `[10-15s]`
* deterministic integer and fractional Timeline boundaries
* sequential chunk-local prompt generation
* sequence progress and cancellation
* exact chunk failure reporting
* cumulative provider request/accounting information
* final-stage provider/model lifecycle handling

The shared preamble contains persistent sequence-level information that Continuum prepends to every resolved chunk, including appropriate identity, wardrobe, environment, style, camera, lighting, audio, continuity, and exclusion constraints.

## Sequence planner and validation

Add a dedicated structured Continuum planning contract before chunk generation.

The planner describes:

* stable subjects
* persistent references
* sequence-wide continuity
* persistent constraints
* per-chunk semantics
* reference scope
* the shared sequence preamble

Writer validates the complete plan before generating chunks.

Validation covers:

* exact chunk count
* required plan structure and field types
* non-empty shared preamble
* stable numeric subject identities
* known reference identities
* reference scope
* subject/reference drift
* Timeline structure
* chunk-local semantics
* shared-preamble duplication
* standalone H3 wrappers inside chunks
* nested Timeline headers
* undeclared subject identities
* invalid keyframe-alignment boilerplate

### Bounded planner recovery

Planner recovery remains deliberately bounded.

Writer can:

* extract one identifiable JSON plan from harmless wrapper prose
* normalize optional internal empty-text fields
* remove application-owned indexes/assignments supplied by the model
* canonicalize reserved aliases such as `<Subject A>` to the required numeric identity
* synthesize a missing shared preamble only from already-known plan semantics and authoritative persistent references
* perform at most one complete-contract LLM repair when deterministic normalization is insufficient

The repair call receives the **full planner contract**, avoiding the failure mode where repairing one field produced another structurally invalid plan.

Missing chunk semantics, incorrect chunk counts, identity drift, invalid reference scope, and other substantive contract violations remain hard errors.

## Continuum reference identity contract

Reference identities are derived from the actual selected Continuum workflow topology rather than guessed from Prompt Writer uploads.

For supported V3.4–V3.7 samplers:

* active **Reference Image** inputs own compact `<Picture 1..N>` identities in hybrid workflows
* when Reference Images are absent, active **First Frame / Last Frame** keyframe inputs own compact temporal `<Picture N>` identities
* **Video Reference** is persistent `<Video 1>`
* V3.5+ **Reference Audio** is persistent `<Audio 1>`
* **Driving Audio** remains persistent conditioning without an `<Audio N>` prompt tag
* V3.7 **Still Image Guide** remains workflow-owned and intentionally receives no Prompt Writer reference tag

Public identities remain stable across planning, generation, refinement, persistence, and graph handoff.

## Workflow references and model-visible media

The contribution separates two concepts that previously could be conflated:

1. references that condition the downstream H3 Continuum workflow
2. images/video actually supplied to the prompt model for visual analysis

A downstream workflow reference can therefore exist in the Continuum inventory without its pixels being uploaded or analyzed by the prompt model.

For **Reference + H3 Continuum**, the Media UI now exposes **Active workflow images** and allows stable workflow references to be imported into Prompt Writer explicitly.

Imported media receives an exact `model_asset_id` binding to the downstream reference identity.

Validation rejects:

* missing model bindings
* wrong media types
* duplicate bindings
* stale bindings
* unrelated replacement media attempting to retain an old workflow identity

Manually replacing imported media drops the workflow binding so unrelated pixels cannot masquerade as the original downstream `<Picture N>`.

## Image Conveyor integration

Add first-class compatibility with **ComfyUI Image Conveyor**.

Prompt Writer resolves Image Conveyor's effective runtime reference topology rather than trusting saved wires alone.

Supported behavior includes:

* persistent Reference Shelf population
* Reference Shelf output enable/disable state
* Main Frame switch
* Last Frame switch
* Queue execution groups
* **Images per execution**
* legacy node alias compatibility
* stable single-image transform/bypass paths

Disabled or empty shelf slots remain outside the public Continuum Picture inventory.

Dynamic queue-driven sources remain visible as downstream conditioning without being falsely imported as stable prompt-model media when their exact execution pixels are not yet available.

### Source drift protection

Stable Image Conveyor Reference Shelf sources receive opaque saved fingerprints.

Changing a shelf image therefore causes Continuum to report source drift instead of silently reusing the same `<Picture N>` identity for different pixels.

Queue-group members remain dynamic by design.

Legacy saved inventories without fingerprints can be accepted once when the topology otherwise matches and are upgraded on successful use.

## Scale Image to Total Pixels Advanced integration

Add exact pre-execution materialization for stable image references passed through the reviewed **Scale Image to Total Pixels Adv / ImageScaleToTotalPixelsX** node.

Supported static transform chains can now materialize the actual reference that H3 will receive instead of rejecting every processed image path.

Supported contract includes:

* static megapixel settings
* multiple-of settings
* stretch
* crop
* pad
* Lanczos interpolation

Transform parameters become part of source identity.

Changing a scaler parameter therefore produces **Update needed** rather than silently continuing with an obsolete Prompt Writer copy.

The implementation fails closed when settings are not statically knowable, including runtime-connected overrides for:

* width
* height
* megapixels
* multiple-of
* resize mode
* interpolation

Unsupported interpolation methods, animated sources, arbitrary processing chains, and unsupported upstreams remain unavailable.

After successful materialization, the Active workflow images preview shows the actual post-transform Prompt Writer asset seen by the prompt model.

## Apply to Continuum

Add an explicit graph handoff for **H3 Continuum Sampler V3.4–V3.7**.

Writer can:

* identify the supported Continuum sampler unambiguously
* validate the selected sampler topology
* validate temporal mode against First/Last Frame wiring
* compare the current downstream conditioning inventory against the inventory used during generation
* detect settings mismatches before applying
* target the connected Text (Multiline) Sequence Prompt
* apply canonical **Prompt Format = Timeline**
* synchronize supported Continuum settings
* fall back to clipboard when direct graph application is unavailable

### Transactional graph mutation

**Sync settings & apply** is transactional.

Writer resolves the target before mutation and restores affected sampler/text widget values if a graph callback fails.

This avoids partially mutating the workflow when application cannot complete.

## Chunk-local refinement

Continuum refinement operates on an individual chunk while retaining the sequence contract.

Unchanged chunks and the shared preamble remain intact.

Refinement revalidates:

* stable subject identities
* public reference inventory
* reference scope
* workflow source topology
* Timeline structure
* sequence settings

Hashes are computed from the exact resolved prompts that Continuum receives.

Saved downstream-conditioning snapshots prevent later refinement from silently reusing an identity after observable workflow rewiring.

## Draft persistence

Add schema-v2 Continuum draft persistence.

Saved sequences retain:

* settings
* structured plan
* shared preamble
* generated chunks
* downstream reference inventory
* source fingerprints
* canonical Timeline output where available

Legacy schema-v1 drafts migrate to v2.

Legacy `[Chunk N]` migration is restricted to genuinely legacy data so a current Timeline sequence cannot accidentally discard its shared preamble.

Provider secrets are never stored in Continuum draft state.

## LM Studio / Custom API provider fix

This contribution also fixes local **LM Studio** discovery when LM Studio runs on another machine on the user's private network.

Prompt Writer already uses LM Studio's `/api/v1/models` metadata to obtain more accurate local model information, including:

* model type
* context length
* vision capability
* LM Studio compatibility detection

That metadata path was previously restricted to loopback addresses such as:

`127.0.0.1`

As a result, a valid Custom OpenAI-compatible LM Studio endpoint such as:

`http://192.168.178.20:1234/v1`

could connect through the generic API transport while missing the LM Studio-specific metadata enrichment.

The detection path now permits both:

* loopback endpoints
* private-LAN endpoints already accepted by the Custom-provider security policy

Public arbitrary HTTP endpoints remain disallowed.

A dedicated regression test verifies LM Studio detection and `/api/v1/models` metadata lookup through a private-LAN Custom endpoint.

Existing LM Studio handling remains intact, including vision-capability enrichment, context metadata, filtering non-LLM entries, and LM Studio-compatible reasoning controls.

## Provider behavior

Continuum sequences can use the existing provider families:

* Direct GGUF
* Ollama
* External llama.cpp
* API providers

A Continuum sequence normally requires one planning call plus one generation call per chunk. The bounded repair paths can add calls only when an objective contract failure requires them.

Workflow-only Continuum conditioning remains metadata and does not inherently require a vision-capable prompt model.

If Prompt Writer itself is asked to inspect image/video pixels, normal provider visual-capability requirements still apply.

## CI and cross-repository contracts

Expand CI from the previous single environment into explicit repository and integration contracts.

### Python

Run the full Python suite on:

* Python **3.10**
* Python **3.12**
* Python **3.13**

Also run:

* Ruff fatal/static checks
* Python compile checks

### Frontend

Run under Node 22:

* JavaScript syntax validation
* frontend regression suite
* Continuum/Image Conveyor frontend integration tests

### H3 Continuum contract

Pin and test against the reviewed official source:

`ukr8b3g-cmyk/ComfyUI-H3-Continuum@0a7c6703b7715689c7aab4177e44e5fcd318fe5b`

The contract validates Writer output against the real Continuum parser and verifies resolved prompt content/hashes.

### Image Conveyor contract

Pin integration coverage against:

`xmarre/ComfyUI-Image-Conveyor@e316cb028f21105a8ea303ace30d9d92acff6198`

This covers both Prompt Writer integration and reviewed Image Conveyor topology behavior.

### Scale Image contract

Pin integration coverage against:

`BigStationW/ComfyUi-Scale-Image-to-Total-Pixels-Advanced@79e831097bb7a76ade3a28359300e62332086c42`

### Windows packaging

CI builds and tests:

* extension ZIP
* standalone Windows ZIP
* standalone runtime tests

### Repository hygiene

Add an explicit `git diff --check` hygiene lane.

## Documentation

Update the README, provider documentation, usage documentation, troubleshooting guidance, Direct/External provider guidance, and changelog for:

* H3 Continuum generation
* V3.4–V3.7 compatibility
* Timeline format
* chunk durations
* reference identity rules
* Reference Audio / Driving Audio semantics
* Image Conveyor integration
* scaler materialization
* workflow-reference binding
* provider call budgeting
* text-only workflow-only Continuum usage
* graph handoff and failure behavior

## Validation

The contribution is one squashed commit on current upstream `main`:

`424248b3153d5792de2b74651bdeb97789892464`

Exact contribution head:

`cacb8f4c797b277ca17538c0386ad4378962473a`

Final validation run:

`33559392449`

passed:

* Python 3.10: **409 tests**, 7 skipped
* Python 3.12: **409 tests**, 7 skipped
* Python 3.13: **409 tests**, 7 skipped
* frontend: **113/113**
* official H3 Continuum V3.4–V3.7 contract: **103 tests**
* Image Conveyor Prompt Writer contract: **4**
* Image Conveyor topology suites: **43/43**
* Scale Image contract: **2**
* Windows extension ZIP: **built successfully**
* Windows standalone ZIP: **built successfully**
* standalone tests: **17**
* repository hygiene: **passed**

A previous full CodeRabbit review of the Continuum work produced three actionable findings. All three were fixed and their review threads resolved. The final V3.4–V3.7-aligned revision above subsequently passed the complete CI matrix.
